### PR TITLE
Fix issue #14: Superuser not created on container run

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -18,9 +18,9 @@ echo "PostgreSQL started"
 python manage.py flush --no-input
 python manage.py migrate
 
-if [ "$(python manage.py shell -c "from django.contrib.auth.models import User; print(User.objects.filter(username='admin').exists())")" ]; then
+if [ "$(python manage.py shell -c 'from accounts.models import User; print(User.objects.filter(username="admin", email="'"$PGADMIN_DEFAULT_EMAIL"'").exists())')" = "False" ]; then
   echo "Creating superuser..."
-  "$(python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_superuser('admin', password='admin')")"
+  python manage.py shell -c 'from accounts.models import User; User.objects.create_superuser("admin", "'"$PGADMIN_DEFAULT_EMAIL"'", password="'"$PGADMIN_DEFAULT_PASSWORD"'")'
   echo "Superuser is created"
 else
   echo "Superuser already exists. Skipping creation."


### PR DESCRIPTION
## Changes made:

1. Changed the outer double quotes to single quotes in the `if condition` to avoid issues with nested double quotes.
2. Changed the import of the `User` model - since the default User model has been swapped with a custom User model in the `accounts` app which was leading to error ->
``` 
AttributeError: Manager isn't available; 'auth.User' has been swapped for 'accounts.User' 
```
3. Added the email field when creating the super user 
4. Added *email* and *password* fields to be used from the environment variables - I think it is more convinient to use it that way.