### PR TITLE
Backend/CF-36 Include custom fields username and email in token payload

### DIFF
--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 User = get_user_model()
 
@@ -20,3 +21,14 @@ class RegistrationSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         user = User.objects.create_user(**validated_data)
         return user
+
+
+class MyTokenObtainPairSerializer(TokenObtainPairSerializer):
+    @classmethod
+    def get_token(cls, user):
+        token = super().get_token(user)
+
+        token['username'] = user.username
+        token['email'] = user.email
+
+        return token

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -1,8 +1,8 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from rest_framework_simplejwt.views import TokenRefreshView
 
-from accounts.views import RegistrationView
+from accounts.views import RegistrationView, MyTokenObtainPairView
 
 router = DefaultRouter()
 
@@ -10,6 +10,6 @@ router.register('register', RegistrationView, basename='register')
 
 urlpatterns = [
     path('', include(router.urls)),
-    path('login/', TokenObtainPairView.as_view(), name='login'),
+    path('login/', MyTokenObtainPairView.as_view(), name='login'),
     path('refresh/', TokenRefreshView.as_view(), name='refresh'),
 ]

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,11 +1,15 @@
 from django.contrib.auth import get_user_model
 from rest_framework import viewsets
 from rest_framework.response import Response
-from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.views import TokenObtainPairView
 
-from accounts.serializers import RegistrationSerializer
+from accounts.serializers import RegistrationSerializer, MyTokenObtainPairSerializer
 
 User = get_user_model()
+
+
+class MyTokenObtainPairView(TokenObtainPairView):
+    serializer_class = MyTokenObtainPairSerializer
 
 
 class RegistrationView(viewsets.ModelViewSet):
@@ -17,7 +21,7 @@ class RegistrationView(viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
 
-        refresh = RefreshToken.for_user(user)
+        refresh = MyTokenObtainPairSerializer.get_token(user)
         access_token = refresh.access_token
 
         return Response({


### PR DESCRIPTION
Added the `username` and `email` fields to the payload of the JWT access token - which looks like this when decoded:


```json
Payload

{
  "token_type": "access",
  "exp": 1700758582,
  "iat": 1700754982,
  "jti": "87d5c334749b4bc0a5fea41f6b6daaf8",
  "user_id": 2,
  "username": "admin2",
  "email": "admin2@do.lab"
}
```
>[!NOTE]
>Please let me know if something is not correct or we need to add something else.