### PR TITLE
Disabling custom middleware related to fix issue #18

### DIFF
--- a/backend/cardflow/settings.py
+++ b/backend/cardflow/settings.py
@@ -50,7 +50,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "accounts.middleware.JWTAuthorizationMiddleware",
+    # "accounts.middleware.JWTAuthorizationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]


### PR DESCRIPTION
I have disabled the custom middleware since it is a bit overkill at this moment, while the standard JWT middleware is doing the same work and we can take advantage from the permission classes for controlling the access to the endpoints without excluding them in a list one by one.

It is just commented it in `settings.py` so we can have it for later on, if needed.

Please let me know if this fixes the issue for now, or should I re-thing the logic of the custom middleware and fix it there.



