### PR TITLE
Adding search by card_in_set_id query param to the listing endpoint

### DIFF
--- a/backend/listing/filters.py
+++ b/backend/listing/filters.py
@@ -16,6 +16,23 @@ class ListingFilter(filters.FilterSet):
         label='Search by is_sold (true or false)'
     )
 
+    card_in_set_id = filters.NumberFilter(
+
+        field_name='card',
+        lookup_expr='exact',
+        label='Search by card_set_id'
+    )
+
     class Meta:
         model = Listing
-        fields = ['is_listed', 'is_sold']
+        fields = ['card', 'is_listed', 'is_sold']
+
+    @property
+    def qs(self):
+        request = self.request
+        card_in_set_param = request.query_params.get('card_in_set_id', None)
+
+        if card_in_set_param:
+            return super().qs.filter(is_listed=True)
+
+        return super().qs

--- a/backend/listing/views.py
+++ b/backend/listing/views.py
@@ -1,7 +1,6 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
 from rest_framework import permissions
-
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response


### PR DESCRIPTION
This PR fix the need in issue #32 by adding additional query param to the **endpoint : api/listing**

**Example**:
`/api/listing/?card_in_set_id=<number>` -> returns all listings from all users related to the the card in set ID which have *is_listed=true* 
> [!NOTE]
> The QuerySet response returned by this request is configured to return only the listings which are listed for all users. 
*It can be changed to return all visible and unvisible listings and then the front end to filter with additional query param `&is_listed=true`*

For instance if we assume that the card we need to show all currently available listings has   ID:20 the following request to `/api/listing/?card_in_set_id=20` will return below response

``` json
"results": [
        {
            "id": 2,
            "card": 20,
            "card_name": "Dark Magician",
            "card_set_id": 20,
            "user": 2,
            "user_name": "admin2",
            "price": 22.0,
            "condition": "poor",
            "quantity": 333,
            "is_listed": true,
            "is_sold": false
        },
        {
            "id": 4,
            "card": 20,
            "card_name": "Dark Magician",
            "card_set_id": 20,
            "user": 1,
            "user_name": "admin",
            "price": 33.0,
            "condition": "mint",
            "quantity": 1,
            "is_listed": true,
            "is_sold": false
        }
    ]
```
