### PR TITLE
Allowing searching in card_in_set endpoint by card_name

### DIFF
--- a/backend/yugioh/filters.py
+++ b/backend/yugioh/filters.py
@@ -1,5 +1,6 @@
 from django_filters import rest_framework as filters
-from .models import YugiohCard
+
+from .models import YugiohCard, YugiohCardInSet
 
 
 class YugiohCardFilter(filters.FilterSet):
@@ -12,3 +13,15 @@ class YugiohCardFilter(filters.FilterSet):
     class Meta:
         model = YugiohCard
         fields = ['card_name']
+
+
+class YugiohCardInSetFilter(filters.FilterSet):
+    card_name = filters.CharFilter(
+        field_name='yugioh_card__card_name',
+        lookup_expr='icontains',
+        label='Search by card name',
+    )
+
+    class Meta:
+        model = YugiohCardInSet
+        fields = ['yugioh_card']

--- a/backend/yugioh/views.py
+++ b/backend/yugioh/views.py
@@ -5,7 +5,7 @@ from rest_framework import permissions
 
 from .models import YugiohCard, YugiohCardInSet
 from .serializers import YugiohCardInSetSerializer, YugiohCardSerializer
-from .filters import YugiohCardFilter
+from .filters import YugiohCardFilter, YugiohCardInSetFilter
 
 
 @extend_schema(tags=['Yu-Gi-Oh Card'])
@@ -34,4 +34,6 @@ class YugiohCardInSetViewSet(viewsets.ModelViewSet):
     serializer_class = YugiohCardInSetSerializer
     permission_classes = [permissions.AllowAny]
     filter_backends = [DjangoFilterBackend]
+    filterset_class = YugiohCardInSetFilter
     http_method_names = ['get']
+


### PR DESCRIPTION
As requested in issue #35 it is now added to search for a card name in `/api/yugioh/cards_in_set/` endpoint

For example request to `/api/yugioh/cards_in_set/?card_name=Dragon` returns paginated result:
``` json
{
    "count": 20,
    "next": "http://localhost:8000/api/yugioh/cards_in_set/?card_name=Dragon&page=2",
    "previous": null,
    "results": [
        {
            "id": 87,
            "yugioh_card": {
                "id": 6,
                "card_name": "Borreload Dragon",
                "type": "Link Monster",
                "frame_type": "link",
                "description": "3+ Effect Monsters\r\nNeither player can target this card with monster effects. Once per turn (Quick Effect): You can target 1 face-up monster on the field; it loses 500 ATK/DEF. Your opponent cannot activate cards or effects in response to this effect's activation. At the start of the Damage Step, if this card attacks an opponent's monster: You can place that opponent's monster in a zone this card points to and take control of it, but send it to the GY during the End Phase of the next turn.",
                "attack": "3000",
                "defense": "NULL",
                "level": "NULL",
                "race": "Dragon",
                "attribute": "DARK",
                "archetype": "Borrel",
                "image": "https://images.ygoprodeck.com/images/cards/31833038.jpg"
            },
            "set": {
                "id": 71,
                "card_set_name": "2018 Mega-Tin Mega Pack",
                "set_code": "MP18"
            },
            "rarity": {
                "id": 2,
                "rarity": "Secret Rare",
                "rarity_code": "(ScR)"
            }
        },
        {
            "id": 88,
            "yugioh_card": {
                "id": 6,
                "card_name": "Borreload Dragon",
                "type": "Link Monster",
                "frame_type": "link",
                "description": "3+ Effect Monsters\r\nNeither player can target this card with monster effects. Once per turn (Quick Effect): You can target 1 face-up monster on the field; it loses 500 ATK/DEF. Your opponent cannot activate cards or effects in response to this effect's activation. At the start of the Damage Step, if this card attacks an opponent's monster: You can place that opponent's monster in a zone this card points to and take control of it, but send it to the GY during the End Phase of the next turn.",
                "attack": "3000",
                "defense": "NULL",
                "level": "NULL",
                "race": "Dragon",
                "attribute": "DARK",
                "archetype": "Borrel",
                "image": "https://images.ygoprodeck.com/images/cards/31833038.jpg"
            },
            "set": {
                "id": 72,
                "card_set_name": "Circuit Break",
                "set_code": "CIBR"
            },
            "rarity": {
                "id": 2,
                "rarity": "Secret Rare",
                "rarity_code": "(ScR)"
            }
        }, 
       ...]
     } 
```