### PR TITLE
Create sell management page

### DIFF
--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -25,10 +25,10 @@ function PageHeader(props: PageHeaderProps): JSX.Element {
 
   return (
     <header
-      className={`lg:pl-24 flex justify-between flex-row pb-8 pt-8 border-b-2 border-stone-300 text-center lg:text-left bg-white ${className}`}
+      className={`lg:pl-24 gap-4 lg:gap-0 flex flex-col items-center justify-center lg:justify-between lg:flex-row pb-8 pt-8 border-b-2 border-stone-300 text-center lg:text-left bg-white ${className}`}
     >
       <h1 className="text-3xl font-bold">{props.heading}</h1>
-      <div className="pr-8">{props.children}</div>
+      <div className="lg:pr-8">{props.children}</div>
     </header>
   );
 }

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -25,10 +25,10 @@ function PageHeader(props: PageHeaderProps): JSX.Element {
 
   return (
     <header
-      className={`lg:pl-24 pb-8 pt-8 border-b-2 border-stone-300 text-center lg:text-left bg-white ${className}`}
+      className={`lg:pl-24 flex justify-between flex-row pb-8 pt-8 border-b-2 border-stone-300 text-center lg:text-left bg-white ${className}`}
     >
       <h1 className="text-3xl font-bold">{props.heading}</h1>
-      {props.children}
+      <div className="pr-8">{props.children}</div>
     </header>
   );
 }

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -13,7 +13,7 @@ export const api = Object.freeze({
   yugioh: {
     listing: {
       root: listing,
-      id: (id: number | string) => `${listing}/${id}`,
+      id: (id: number | string) => `${listing}/${id}/`,
       buyById: (id: number | string) => `${listing}/${id}/buy/`,
     },
     cardInSet: {

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, Link } from '@mui/material';
+import { Button, Checkbox, Link, Menu, MenuItem } from '@mui/material';
 import MarketTable from '../../components/marketTable/MarketTable';
 import { YugiohCardListing } from '../../services/yugioh/types';
 import React, { Reducer, useEffect, useReducer } from 'react';
@@ -46,6 +46,19 @@ function SellManagement(): JSX.Element {
   const [data, dispatch] = useReducer(selectReducer, [] as ListingData[]);
   const { user } = useCurrentUser();
   const { isAuthenticated } = useAuthenticationStatus();
+
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  function openMenu(event: React.MouseEvent<HTMLElement>) {
+    event.preventDefault();
+    setAnchorEl(event.currentTarget);
+  }
+
+  function closeMenu(event: React.MouseEvent) {
+    event.preventDefault();
+    setAnchorEl(null);
+  }
 
   function retrieveListings() {
     yugiohService.getCardListingsByUserId(user.user_id).then((listings) => {
@@ -146,7 +159,15 @@ function SellManagement(): JSX.Element {
           <Button variant="outlined" color="error" onClick={deleteAll}>
             Delete all
           </Button>
-          <Button variant="outlined">. . .</Button>
+          <Button variant="outlined" onClick={openMenu}>
+            . . .
+          </Button>
+          <Menu open={open} anchorEl={anchorEl} onClose={closeMenu}>
+            <MenuItem>Delete selected items</MenuItem>
+            <MenuItem>Unlist selected items</MenuItem>
+            <MenuItem>List selected items</MenuItem>
+            <MenuItem>List all</MenuItem>
+          </Menu>
         </div>
       </div>
     </section>

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -123,6 +123,20 @@ function SellManagement(): JSX.Element {
     });
   }
 
+  function delistSelectedItems(event: React.MouseEvent) {
+    event.preventDefault();
+    const fetchFunctions = data
+      .filter((d) => d.selected)
+      .map((d) => {
+        return yugiohService.editListing({ ...d.listing, is_listed: false });
+      });
+
+    Promise.all(fetchFunctions).then(() => {
+      retrieveListings();
+      setAnchorEl(null);
+    });
+  }
+
   useEffect(() => {
     if (isAuthenticated) {
       retrieveListings();
@@ -180,7 +194,9 @@ function SellManagement(): JSX.Element {
             <MenuItem disabled={data.every((d) => !d.selected)} onClick={deleteSelectedItems}>
               Delete selected items
             </MenuItem>
-            <MenuItem>Unlist selected items</MenuItem>
+            <MenuItem disabled={data.every((d) => !d.selected)} onClick={delistSelectedItems}>
+              Delist selected items
+            </MenuItem>
             <MenuItem>List selected items</MenuItem>
             <MenuItem>List all</MenuItem>
           </Menu>

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -8,6 +8,7 @@ import YugiohCardConditionLabel from '../../components/yugioh/YugiohCardConditio
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import PageHeader from '../../components/PageHeader';
 import LensIcon from '@mui/icons-material/Lens';
+import AddIcon from '@mui/icons-material/Add';
 
 type ListingData = {
   listing: YugiohCardListing;
@@ -199,7 +200,7 @@ function SellManagement(): JSX.Element {
     <section className="bg-[#F5F5F5] min-h-[100vh]">
       <PageHeader heading="Sell">
         {/* TO-DO: update URL */}
-        <Button href="/listing/new" variant="outlined" color="success">
+        <Button startIcon={<AddIcon />} href="/listing/new" variant="outlined" color="success">
           New Listing
         </Button>
       </PageHeader>

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -98,6 +98,18 @@ function SellManagement(): JSX.Element {
     });
   }
 
+  function listAll(event: React.MouseEvent) {
+    event.preventDefault();
+    const fetchFunctions = data.map((d) => {
+      return yugiohService.editListing({ ...d.listing, is_listed: true });
+    });
+
+    Promise.all(fetchFunctions).then(() => {
+      retrieveListings();
+      setAnchorEl(null);
+    });
+  }
+
   function deleteAll(event: React.MouseEvent) {
     event.preventDefault();
     const fetchFunctions = data.map((d) => {
@@ -214,7 +226,7 @@ function SellManagement(): JSX.Element {
             <MenuItem disabled={data.every((d) => !d.selected)} onClick={listSelectedItems}>
               List selected items
             </MenuItem>
-            <MenuItem>List all</MenuItem>
+            <MenuItem onClick={listAll}>List all</MenuItem>
           </Menu>
         </div>
       </div>

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -1,0 +1,116 @@
+import { Checkbox, Link } from '@mui/material';
+import MarketTable from '../../components/marketTable/MarketTable';
+import { YugiohCardListing } from '../../services/yugioh/types';
+import React, { Reducer, useEffect, useReducer } from 'react';
+import { yugiohService } from '../../services/yugioh/yugiohService';
+import { useAuthenticationStatus, useCurrentUser } from '../../context/user';
+import YugiohCardConditionLabel from '../../components/yugioh/YugiohCardConditionLabel';
+
+type ListingData = {
+  listing: YugiohCardListing;
+  selected: boolean;
+};
+
+type selectReducerAction = {
+  type: 'select' | 'deselect' | 'set' | 'selectAll' | 'deselectAll';
+  index?: number;
+  checked?: boolean;
+  newListings?: ListingData[];
+};
+
+function selectReducer(
+  state: ListingData[],
+  action: selectReducerAction,
+): React.ReducerState<Reducer<typeof state, typeof action>> {
+  switch (action.type) {
+    case 'select':
+      const listingsForSelect = [...state];
+      listingsForSelect[action.index || 0].selected = true;
+      return listingsForSelect;
+    case 'deselect':
+      const listingsForDeselect = [...state];
+      listingsForDeselect[action.index || 0].selected = false;
+      return listingsForDeselect;
+    case 'set':
+      return action.newListings || [];
+    case 'selectAll':
+      return state.map((ld) => ({ ...ld, selected: true }));
+    case 'deselectAll':
+      return state.map((ld) => ({ ...ld, selected: false }));
+    default:
+      throw new Error('Unknown action');
+  }
+}
+
+function SellManagement(): JSX.Element {
+  const [data, dispatch] = useReducer(selectReducer, [] as ListingData[]);
+  const { user } = useCurrentUser();
+  const { isAuthenticated } = useAuthenticationStatus();
+
+  function handleCheck(index: number) {
+    dispatch({
+      type: data[index].selected ? 'deselect' : 'select',
+      index,
+    });
+  }
+
+  function handleCheckAll() {
+    dispatch({
+      type: data.every((d) => d.selected) ? 'deselectAll' : 'selectAll',
+    });
+  }
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      yugiohService.getCardListingsByUserId(user.user_id).then((listings) => {
+        const data: ListingData[] = listings.results.map((l) => ({
+          listing: l,
+          selected: false,
+        }));
+
+        dispatch({
+          type: 'set',
+          newListings: data,
+        });
+      });
+    }
+  }, [user.user_id]);
+  return (
+    <MarketTable>
+      <thead>
+        <tr>
+          <th>
+            <Checkbox onChange={handleCheckAll} color="default" />
+          </th>
+          <th colSpan={2}>Card details</th>
+          <th>Available</th>
+          <th>Price</th>
+          <th>Listed</th>
+        </tr>
+        {data.map((ld, i) => (
+          <tr key={ld.listing.id}>
+            <td>
+              <Checkbox
+                onChange={() => {
+                  handleCheck(i);
+                }}
+                checked={data[i].selected}
+              />
+            </td>
+            <td>
+              <Link>{ld.listing.card_name}</Link>
+            </td>
+            <td>
+              <YugiohCardConditionLabel condition={ld.listing.condition} />
+            </td>
+            <td>{ld.listing.quantity}</td>
+            <td>$&nbsp;{ld.listing.price}</td>
+            <td>{ld.listing.is_listed}</td>
+          </tr>
+        ))}
+      </thead>
+    </MarketTable>
+  );
+}
+
+export default SellManagement;

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -82,6 +82,7 @@ function SellManagement(): JSX.Element {
       });
 
       setCheckedAll(false);
+      setPage(page);
     });
   }
 
@@ -117,7 +118,7 @@ function SellManagement(): JSX.Element {
     });
 
     Promise.all(fetchFunctions).then(() => {
-      retrieveListings(page);
+      retrieveListings(1);
     });
   }
 
@@ -139,8 +140,15 @@ function SellManagement(): JSX.Element {
       return yugiohService.deleteListingById(d.listing.id);
     });
 
+    let newPage: number;
+    if (data.length > fetchFunctions.length) {
+      newPage = page;
+    } else {
+      newPage = page === pages && page !== 1 ? page - 1 : page;
+    }
+
     Promise.all(fetchFunctions).then(() => {
-      retrieveListings(page);
+      retrieveListings(newPage);
     });
   }
 
@@ -152,8 +160,15 @@ function SellManagement(): JSX.Element {
         return yugiohService.deleteListingById(d.listing.id);
       });
 
+    let newPage: number;
+    if (data.length > fetchFunctions.length) {
+      newPage = page;
+    } else {
+      newPage = page === pages && page !== 1 ? page - 1 : page;
+    }
+
     Promise.all(fetchFunctions).then(() => {
-      retrieveListings(page);
+      retrieveListings(newPage);
       setAnchorEl(null);
     });
   }

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -1,10 +1,11 @@
-import { Button, Checkbox, Link, Menu, MenuItem } from '@mui/material';
+import { Button, Checkbox, IconButton, Link, Menu, MenuItem } from '@mui/material';
 import MarketTable from '../../components/marketTable/MarketTable';
 import { YugiohCardListing } from '../../services/yugioh/types';
 import React, { Reducer, useEffect, useReducer } from 'react';
 import { yugiohService } from '../../services/yugioh/yugiohService';
 import { useAuthenticationStatus, useCurrentUser } from '../../context/user';
 import YugiohCardConditionLabel from '../../components/yugioh/YugiohCardConditionLabel';
+import VisibilityIcon from '@mui/icons-material/Visibility';
 
 type ListingData = {
   listing: YugiohCardListing;
@@ -163,6 +164,9 @@ function SellManagement(): JSX.Element {
     });
   }
 
+  function toggleListingVisibility(listing: YugiohCardListing, newStatus: boolean) {
+    yugiohService.editListing({ ...listing, is_listed: newStatus }).then(() => retrieveListings());
+  }
   useEffect(() => {
     if (isAuthenticated) {
       retrieveListings();
@@ -199,7 +203,14 @@ function SellManagement(): JSX.Element {
               </td>
               <td>{ld.listing.quantity}</td>
               <td>$&nbsp;{ld.listing.price}</td>
-              <td>{ld.listing.is_listed.toString()}</td>
+              <td>
+                <IconButton
+                  onClick={() => toggleListingVisibility(ld.listing, !ld.listing.is_listed)}
+                  sx={{ color: ld.listing.is_listed ? 'blue' : 'inherit' }}
+                >
+                  <VisibilityIcon />
+                </IconButton>
+              </td>
             </tr>
           ))}
         </thead>

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -137,6 +137,20 @@ function SellManagement(): JSX.Element {
     });
   }
 
+  function listSelectedItems(event: React.MouseEvent) {
+    event.preventDefault();
+    const fetchFunctions = data
+      .filter((d) => d.selected)
+      .map((d) => {
+        return yugiohService.editListing({ ...d.listing, is_listed: true });
+      });
+
+    Promise.all(fetchFunctions).then(() => {
+      retrieveListings();
+      setAnchorEl(null);
+    });
+  }
+
   useEffect(() => {
     if (isAuthenticated) {
       retrieveListings();
@@ -197,7 +211,9 @@ function SellManagement(): JSX.Element {
             <MenuItem disabled={data.every((d) => !d.selected)} onClick={delistSelectedItems}>
               Delist selected items
             </MenuItem>
-            <MenuItem>List selected items</MenuItem>
+            <MenuItem disabled={data.every((d) => !d.selected)} onClick={listSelectedItems}>
+              List selected items
+            </MenuItem>
             <MenuItem>List all</MenuItem>
           </Menu>
         </div>

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Link } from '@mui/material';
+import { Button, Checkbox, Link } from '@mui/material';
 import MarketTable from '../../components/marketTable/MarketTable';
 import { YugiohCardListing } from '../../services/yugioh/types';
 import React, { Reducer, useEffect, useReducer } from 'react';
@@ -76,40 +76,52 @@ function SellManagement(): JSX.Element {
     }
   }, [user.user_id]);
   return (
-    <MarketTable>
-      <thead>
-        <tr>
-          <th>
-            <Checkbox onChange={handleCheckAll} color="default" />
-          </th>
-          <th colSpan={2}>Card details</th>
-          <th>Available</th>
-          <th>Price</th>
-          <th>Listed</th>
-        </tr>
-        {data.map((ld, i) => (
-          <tr key={ld.listing.id}>
-            <td>
-              <Checkbox
-                onChange={() => {
-                  handleCheck(i);
-                }}
-                checked={data[i].selected}
-              />
-            </td>
-            <td>
-              <Link>{ld.listing.card_name}</Link>
-            </td>
-            <td>
-              <YugiohCardConditionLabel condition={ld.listing.condition} />
-            </td>
-            <td>{ld.listing.quantity}</td>
-            <td>$&nbsp;{ld.listing.price}</td>
-            <td>{ld.listing.is_listed}</td>
+    <section>
+      <MarketTable>
+        <thead>
+          <tr>
+            <th>
+              <Checkbox onChange={handleCheckAll} color="default" />
+            </th>
+            <th colSpan={2}>Card details</th>
+            <th>Available</th>
+            <th>Price</th>
+            <th>Listed</th>
           </tr>
-        ))}
-      </thead>
-    </MarketTable>
+          {data.map((ld, i) => (
+            <tr key={ld.listing.id}>
+              <td>
+                <Checkbox
+                  onChange={() => {
+                    handleCheck(i);
+                  }}
+                  checked={data[i].selected}
+                />
+              </td>
+              <td>
+                <Link>{ld.listing.card_name}</Link>
+              </td>
+              <td>
+                <YugiohCardConditionLabel condition={ld.listing.condition} />
+              </td>
+              <td>{ld.listing.quantity}</td>
+              <td>$&nbsp;{ld.listing.price}</td>
+              <td>{ld.listing.is_listed}</td>
+            </tr>
+          ))}
+        </thead>
+      </MarketTable>
+      <div>
+        <p>{data.filter((d) => d.selected).length} item(s) selected</p>
+        <div>
+          <Button variant="outlined">Delist all</Button>
+          <Button variant="outlined" color="error">
+            Delete all
+          </Button>
+          <Button variant="outlined">. . .</Button>
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -47,6 +47,20 @@ function SellManagement(): JSX.Element {
   const { user } = useCurrentUser();
   const { isAuthenticated } = useAuthenticationStatus();
 
+  function retrieveListings() {
+    yugiohService.getCardListingsByUserId(user.user_id).then((listings) => {
+      const data: ListingData[] = listings.results.map((l) => ({
+        listing: l,
+        selected: false,
+      }));
+
+      dispatch({
+        type: 'set',
+        newListings: data,
+      });
+    });
+  }
+
   function handleCheck(index: number) {
     dispatch({
       type: data[index].selected ? 'deselect' : 'select',
@@ -67,33 +81,13 @@ function SellManagement(): JSX.Element {
     });
 
     Promise.all(fetchFunctions).then(() => {
-      yugiohService.getCardListingsByUserId(user.user_id).then((listings) => {
-        const data: ListingData[] = listings.results.map((l) => ({
-          listing: l,
-          selected: false,
-        }));
-
-        dispatch({
-          type: 'set',
-          newListings: data,
-        });
-      });
+      retrieveListings();
     });
   }
 
   useEffect(() => {
     if (isAuthenticated) {
-      yugiohService.getCardListingsByUserId(user.user_id).then((listings) => {
-        const data: ListingData[] = listings.results.map((l) => ({
-          listing: l,
-          selected: false,
-        }));
-
-        dispatch({
-          type: 'set',
-          newListings: data,
-        });
-      });
+      retrieveListings();
     }
   }, [user.user_id]);
   return (

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -245,7 +245,7 @@ function SellManagement(): JSX.Element {
                   />
                 </td>
                 <td className="w-48 text-center">{ld.listing.quantity}</td>
-                <td className="w-48 text-center">$&nbsp;{ld.listing.price}</td>
+                <td className="w-48 font-bold text-center">$&nbsp;{ld.listing.price}</td>
                 <td className="text-center w-4">
                   <IconButton
                     onClick={() => toggleListingVisibility(ld.listing, !ld.listing.is_listed)}

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -60,6 +60,27 @@ function SellManagement(): JSX.Element {
     });
   }
 
+  function delistAll(event: React.MouseEvent) {
+    event.preventDefault();
+    const fetchFunctions = data.map((d) => {
+      return yugiohService.editListing({ ...d.listing, is_listed: false });
+    });
+
+    Promise.all(fetchFunctions).then(() => {
+      yugiohService.getCardListingsByUserId(user.user_id).then((listings) => {
+        const data: ListingData[] = listings.results.map((l) => ({
+          listing: l,
+          selected: false,
+        }));
+
+        dispatch({
+          type: 'set',
+          newListings: data,
+        });
+      });
+    });
+  }
+
   useEffect(() => {
     if (isAuthenticated) {
       yugiohService.getCardListingsByUserId(user.user_id).then((listings) => {
@@ -106,7 +127,7 @@ function SellManagement(): JSX.Element {
               </td>
               <td>{ld.listing.quantity}</td>
               <td>$&nbsp;{ld.listing.price}</td>
-              <td>{ld.listing.is_listed}</td>
+              <td>{ld.listing.is_listed.toString()}</td>
             </tr>
           ))}
         </thead>
@@ -114,7 +135,9 @@ function SellManagement(): JSX.Element {
       <div>
         <p>{data.filter((d) => d.selected).length} item(s) selected</p>
         <div>
-          <Button variant="outlined">Delist all</Button>
+          <Button variant="outlined" onClick={delistAll}>
+            Delist all
+          </Button>
           <Button variant="outlined" color="error">
             Delete all
           </Button>

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -1,7 +1,7 @@
 import { Button, Checkbox, IconButton, Link, Menu, MenuItem } from '@mui/material';
 import MarketTable from '../../components/marketTable/MarketTable';
 import { YugiohCardListing } from '../../services/yugioh/types';
-import React, { Reducer, useEffect, useReducer } from 'react';
+import React, { Reducer, useEffect, useReducer, useState } from 'react';
 import { yugiohService } from '../../services/yugioh/yugiohService';
 import { useAuthenticationStatus, useCurrentUser } from '../../context/user';
 import YugiohCardConditionLabel from '../../components/yugioh/YugiohCardConditionLabel';
@@ -48,6 +48,7 @@ function SellManagement(): JSX.Element {
   const [data, dispatch] = useReducer(selectReducer, [] as ListingData[]);
   const { user } = useCurrentUser();
   const { isAuthenticated } = useAuthenticationStatus();
+  const [checkedAll, setCheckedAll] = useState(false);
 
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
@@ -85,8 +86,10 @@ function SellManagement(): JSX.Element {
 
   function handleCheckAll() {
     dispatch({
-      type: data.every((d) => d.selected) ? 'deselectAll' : 'selectAll',
+      type: checkedAll && data.some((d) => d.selected) ? 'deselectAll' : 'selectAll',
     });
+
+    setCheckedAll(!checkedAll);
   }
 
   function delistAll(event: React.MouseEvent) {
@@ -186,7 +189,7 @@ function SellManagement(): JSX.Element {
           <thead>
             <tr className="text-center">
               <th>
-                <Checkbox color="info" onChange={handleCheckAll} />
+                <Checkbox checked={checkedAll} color="info" onChange={handleCheckAll} />
               </th>
               <th colSpan={2}>Card details</th>
               <th>Available</th>

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -200,12 +200,18 @@ function SellManagement(): JSX.Element {
     <section className="bg-[#F5F5F5] min-h-[100vh]">
       <PageHeader heading="Sell">
         {/* TO-DO: update URL */}
-        <Button startIcon={<AddIcon />} href="/listing/new" variant="outlined" color="success">
+        <Button
+          className="rounded-md"
+          startIcon={<AddIcon />}
+          href="/listing/new"
+          variant="outlined"
+          color="success"
+        >
           New Listing
         </Button>
       </PageHeader>
       <div className="flex flex-col lg:items-center overflow-auto">
-        <MarketTable className="w-full mt-4 lg:w-10/12 text-left">
+        <MarketTable className="w-full rounded-md mt-4 lg:w-10/12 text-left">
           <thead>
             <tr className="text-center">
               <th>
@@ -262,19 +268,19 @@ function SellManagement(): JSX.Element {
             ))}
           </thead>
         </MarketTable>
-        <div className="text-center self-center mb-4 mt-4 w-96 border-[#666666] border rounded">
+        <div className="text-center self-center mb-4 mt-4 w-96 border-[#666666] border rounded-md">
           <p className="pt-4">
             <strong>{data.filter((d) => d.selected).length}</strong> item(s) selected
           </p>
           <div className="flex justify-between p-4">
-            <Button variant="outlined" onClick={delistAll}>
+            <Button className="rounded-md" variant="outlined" onClick={delistAll}>
               Delist all
             </Button>
-            <Button variant="outlined" color="error" onClick={deleteAll}>
+            <Button className="rounded-md" variant="outlined" color="error" onClick={deleteAll}>
               Delete all
             </Button>
             <Button
-              className="font-bold flex gap-1 items-center justify-center"
+              className="font-bold rounded-md flex gap-1 items-center justify-center"
               variant="outlined"
               onClick={openMenu}
             >

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -85,11 +85,17 @@ function SellManagement(): JSX.Element {
   }
 
   function handleCheckAll() {
-    dispatch({
-      type: checkedAll && data.some((d) => d.selected) ? 'deselectAll' : 'selectAll',
-    });
-
-    setCheckedAll(!checkedAll);
+    if (checkedAll) {
+      if (data.some((d) => !d.selected)) {
+        dispatch({ type: 'selectAll' });
+      } else {
+        dispatch({ type: 'deselectAll' });
+        setCheckedAll(false);
+      }
+    } else {
+      dispatch({ type: 'selectAll' });
+      setCheckedAll(true);
+    }
   }
 
   function delistAll(event: React.MouseEvent) {

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -85,6 +85,17 @@ function SellManagement(): JSX.Element {
     });
   }
 
+  function deleteAll(event: React.MouseEvent) {
+    event.preventDefault();
+    const fetchFunctions = data.map((d) => {
+      return yugiohService.deleteListingById(d.listing.id);
+    });
+
+    Promise.all(fetchFunctions).then(() => {
+      retrieveListings();
+    });
+  }
+
   useEffect(() => {
     if (isAuthenticated) {
       retrieveListings();
@@ -132,7 +143,7 @@ function SellManagement(): JSX.Element {
           <Button variant="outlined" onClick={delistAll}>
             Delist all
           </Button>
-          <Button variant="outlined" color="error">
+          <Button variant="outlined" color="error" onClick={deleteAll}>
             Delete all
           </Button>
           <Button variant="outlined">. . .</Button>

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, IconButton, Link, Menu, MenuItem } from '@mui/material';
+import { Button, Checkbox, IconButton, Link, Menu, MenuItem, Pagination } from '@mui/material';
 import MarketTable from '../../components/marketTable/MarketTable';
 import { YugiohCardListing } from '../../services/yugioh/types';
 import React, { Reducer, useEffect, useReducer, useState } from 'react';
@@ -49,6 +49,8 @@ function SellManagement(): JSX.Element {
   const { user } = useCurrentUser();
   const { isAuthenticated } = useAuthenticationStatus();
   const [checkedAll, setCheckedAll] = useState(false);
+  const [page, setPage] = useState(1);
+  const [pages, setPages] = useState(0);
 
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
@@ -63,12 +65,14 @@ function SellManagement(): JSX.Element {
     setAnchorEl(null);
   }
 
-  function retrieveListings() {
-    yugiohService.getCardListingsByUserId(user.user_id).then((listings) => {
+  function retrieveListings(page: number) {
+    yugiohService.getCardListingsByUserId(user.user_id, page).then((listings) => {
       const data: ListingData[] = listings.results.map((l) => ({
         listing: l,
         selected: false,
       }));
+
+      setPages(Math.ceil(listings.count / 10));
 
       dispatch({
         type: 'set',
@@ -109,7 +113,7 @@ function SellManagement(): JSX.Element {
     });
 
     Promise.all(fetchFunctions).then(() => {
-      retrieveListings();
+      retrieveListings(page);
     });
   }
 
@@ -120,7 +124,7 @@ function SellManagement(): JSX.Element {
     });
 
     Promise.all(fetchFunctions).then(() => {
-      retrieveListings();
+      retrieveListings(page);
       setAnchorEl(null);
     });
   }
@@ -132,7 +136,7 @@ function SellManagement(): JSX.Element {
     });
 
     Promise.all(fetchFunctions).then(() => {
-      retrieveListings();
+      retrieveListings(page);
     });
   }
 
@@ -145,7 +149,7 @@ function SellManagement(): JSX.Element {
       });
 
     Promise.all(fetchFunctions).then(() => {
-      retrieveListings();
+      retrieveListings(page);
       setAnchorEl(null);
     });
   }
@@ -159,7 +163,7 @@ function SellManagement(): JSX.Element {
       });
 
     Promise.all(fetchFunctions).then(() => {
-      retrieveListings();
+      retrieveListings(page);
       setAnchorEl(null);
     });
   }
@@ -173,19 +177,21 @@ function SellManagement(): JSX.Element {
       });
 
     Promise.all(fetchFunctions).then(() => {
-      retrieveListings();
+      retrieveListings(page);
       setAnchorEl(null);
     });
   }
 
   function toggleListingVisibility(listing: YugiohCardListing, newStatus: boolean) {
-    yugiohService.editListing({ ...listing, is_listed: newStatus }).then(() => retrieveListings());
+    yugiohService
+      .editListing({ ...listing, is_listed: newStatus })
+      .then(() => retrieveListings(page));
   }
   useEffect(() => {
     if (isAuthenticated) {
-      retrieveListings();
+      retrieveListings(page);
     }
-  }, [user.user_id]);
+  }, [user.user_id, page]);
   return (
     <section>
       <PageHeader heading="Sell">
@@ -194,7 +200,7 @@ function SellManagement(): JSX.Element {
           New Listing
         </Button>
       </PageHeader>
-      <div className="block lg:flex flex-col items-center overflow-auto">
+      <div className="flex flex-col lg:items-center overflow-auto">
         <MarketTable className="w-full lg:w-10/12 text-left">
           <thead>
             <tr className="text-center">
@@ -252,7 +258,7 @@ function SellManagement(): JSX.Element {
             ))}
           </thead>
         </MarketTable>
-        <div className="text-center mb-4 mt-4 w-96 border-[#666666] border rounded">
+        <div className="text-center self-center mb-4 mt-4 w-96 border-[#666666] border rounded">
           <p className="pt-4">
             <strong>{data.filter((d) => d.selected).length}</strong> item(s) selected
           </p>
@@ -280,6 +286,15 @@ function SellManagement(): JSX.Element {
             </Menu>
           </div>
         </div>
+        <Pagination
+          className="self-center"
+          page={page}
+          onChange={(e, p) => {
+            e.preventDefault();
+            setPage(p);
+          }}
+          count={pages}
+        />
       </div>
     </section>
   );

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -268,7 +268,7 @@ function SellManagement(): JSX.Element {
             ))}
           </thead>
         </MarketTable>
-        <div className="text-center self-center mb-4 mt-4 w-96 border-[#666666] border rounded-md">
+        <div className="text-center bg-white self-center mb-4 mt-4 w-96 border-[#666666] border rounded-md">
           <p className="pt-4">
             <strong>{data.filter((d) => d.selected).length}</strong> item(s) selected
           </p>

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -204,7 +204,7 @@ function SellManagement(): JSX.Element {
         </Button>
       </PageHeader>
       <div className="flex flex-col lg:items-center overflow-auto">
-        <MarketTable className="w-full lg:w-10/12 text-left">
+        <MarketTable className="w-full mt-4 lg:w-10/12 text-left">
           <thead>
             <tr className="text-center">
               <th>

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -78,6 +78,8 @@ function SellManagement(): JSX.Element {
         type: 'set',
         newListings: data,
       });
+
+      setCheckedAll(false);
     });
   }
 

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -109,6 +109,20 @@ function SellManagement(): JSX.Element {
     });
   }
 
+  function deleteSelectedItems(event: React.MouseEvent) {
+    event.preventDefault();
+    const fetchFunctions = data
+      .filter((d) => d.selected)
+      .map((d) => {
+        return yugiohService.deleteListingById(d.listing.id);
+      });
+
+    Promise.all(fetchFunctions).then(() => {
+      retrieveListings();
+      setAnchorEl(null);
+    });
+  }
+
   useEffect(() => {
     if (isAuthenticated) {
       retrieveListings();
@@ -163,7 +177,9 @@ function SellManagement(): JSX.Element {
             . . .
           </Button>
           <Menu open={open} anchorEl={anchorEl} onClose={closeMenu}>
-            <MenuItem>Delete selected items</MenuItem>
+            <MenuItem disabled={data.every((d) => !d.selected)} onClick={deleteSelectedItems}>
+              Delete selected items
+            </MenuItem>
             <MenuItem>Unlist selected items</MenuItem>
             <MenuItem>List selected items</MenuItem>
             <MenuItem>List all</MenuItem>

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -6,6 +6,7 @@ import { yugiohService } from '../../services/yugioh/yugiohService';
 import { useAuthenticationStatus, useCurrentUser } from '../../context/user';
 import YugiohCardConditionLabel from '../../components/yugioh/YugiohCardConditionLabel';
 import VisibilityIcon from '@mui/icons-material/Visibility';
+import PageHeader from '../../components/PageHeader';
 
 type ListingData = {
   listing: YugiohCardListing;
@@ -174,71 +175,96 @@ function SellManagement(): JSX.Element {
   }, [user.user_id]);
   return (
     <section>
-      <MarketTable>
-        <thead>
-          <tr>
-            <th>
-              <Checkbox onChange={handleCheckAll} color="default" />
-            </th>
-            <th colSpan={2}>Card details</th>
-            <th>Available</th>
-            <th>Price</th>
-            <th>Listed</th>
-          </tr>
-          {data.map((ld, i) => (
-            <tr key={ld.listing.id}>
-              <td>
-                <Checkbox
-                  onChange={() => {
-                    handleCheck(i);
-                  }}
-                  checked={data[i].selected}
-                />
-              </td>
-              <td>
-                <Link>{ld.listing.card_name}</Link>
-              </td>
-              <td>
-                <YugiohCardConditionLabel condition={ld.listing.condition} />
-              </td>
-              <td>{ld.listing.quantity}</td>
-              <td>$&nbsp;{ld.listing.price}</td>
-              <td>
-                <IconButton
-                  onClick={() => toggleListingVisibility(ld.listing, !ld.listing.is_listed)}
-                  sx={{ color: ld.listing.is_listed ? 'blue' : 'inherit' }}
-                >
-                  <VisibilityIcon />
-                </IconButton>
-              </td>
+      <PageHeader heading="Sell">
+        {/* TO-DO: update URL */}
+        <Button href="/listing/new" variant="outlined" color="success">
+          New Listing
+        </Button>
+      </PageHeader>
+      <div className="block lg:flex flex-col items-center overflow-auto">
+        <MarketTable className="w-full lg:w-10/12 text-left">
+          <thead>
+            <tr className="text-center">
+              <th>
+                <Checkbox onChange={handleCheckAll} color="default" />
+              </th>
+              <th colSpan={2}>Card details</th>
+              <th>Available</th>
+              <th>Price</th>
+              <th>Listed</th>
             </tr>
-          ))}
-        </thead>
-      </MarketTable>
-      <div>
-        <p>{data.filter((d) => d.selected).length} item(s) selected</p>
-        <div>
-          <Button variant="outlined" onClick={delistAll}>
-            Delist all
-          </Button>
-          <Button variant="outlined" color="error" onClick={deleteAll}>
-            Delete all
-          </Button>
-          <Button variant="outlined" onClick={openMenu}>
-            . . .
-          </Button>
-          <Menu open={open} anchorEl={anchorEl} onClose={closeMenu}>
-            <MenuItem disabled={data.every((d) => !d.selected)} onClick={deleteSelectedItems}>
-              Delete selected items
-            </MenuItem>
-            <MenuItem disabled={data.every((d) => !d.selected)} onClick={delistSelectedItems}>
-              Delist selected items
-            </MenuItem>
-            <MenuItem disabled={data.every((d) => !d.selected)} onClick={listSelectedItems}>
-              List selected items
-            </MenuItem>
-            <MenuItem onClick={listAll}>List all</MenuItem>
-          </Menu>
+            {data.map((ld, i) => (
+              <tr key={ld.listing.id}>
+                <td className="w-2" style={{ paddingLeft: 16, paddingRight: 16 }}>
+                  <Checkbox
+                    onChange={() => {
+                      handleCheck(i);
+                    }}
+                    checked={data[i].selected}
+                  />
+                </td>
+                <td className="text-center w-[110px]">
+                  {/* TO-DO: update URL */}
+                  <Link
+                    sx={{
+                      color: '#0B70E5',
+                      textDecorationColor: '#0B70E5',
+                      textDecoration: 'none',
+                      ':hover': {
+                        textDecoration: 'underline',
+                      },
+                    }}
+                  >
+                    {ld.listing.card_name}
+                  </Link>
+                </td>
+                <td className="w-[110px]">
+                  <YugiohCardConditionLabel
+                    className="w-[110px]"
+                    condition={ld.listing.condition}
+                  />
+                </td>
+                <td className="w-48 text-center">{ld.listing.quantity}</td>
+                <td className="w-48 text-center">$&nbsp;{ld.listing.price}</td>
+                <td className="text-center w-4">
+                  <IconButton
+                    onClick={() => toggleListingVisibility(ld.listing, !ld.listing.is_listed)}
+                    sx={{ color: ld.listing.is_listed ? 'blue' : 'inherit' }}
+                  >
+                    <VisibilityIcon />
+                  </IconButton>
+                </td>
+              </tr>
+            ))}
+          </thead>
+        </MarketTable>
+        <div className="text-center mb-4 mt-4 w-96 border-[#666666] border rounded">
+          <p className="pt-4">
+            <strong>{data.filter((d) => d.selected).length}</strong> item(s) selected
+          </p>
+          <div className="flex justify-between p-4">
+            <Button variant="outlined" onClick={delistAll}>
+              Delist all
+            </Button>
+            <Button variant="outlined" color="error" onClick={deleteAll}>
+              Delete all
+            </Button>
+            <Button variant="outlined" onClick={openMenu}>
+              . . .
+            </Button>
+            <Menu open={open} anchorEl={anchorEl} onClose={closeMenu}>
+              <MenuItem disabled={data.every((d) => !d.selected)} onClick={deleteSelectedItems}>
+                Delete selected items
+              </MenuItem>
+              <MenuItem disabled={data.every((d) => !d.selected)} onClick={delistSelectedItems}>
+                Delist selected items
+              </MenuItem>
+              <MenuItem disabled={data.every((d) => !d.selected)} onClick={listSelectedItems}>
+                List selected items
+              </MenuItem>
+              <MenuItem onClick={listAll}>List all</MenuItem>
+            </Menu>
+          </div>
         </div>
       </div>
     </section>

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -186,7 +186,7 @@ function SellManagement(): JSX.Element {
           <thead>
             <tr className="text-center">
               <th>
-                <Checkbox onChange={handleCheckAll} color="default" />
+                <Checkbox color="info" onChange={handleCheckAll} />
               </th>
               <th colSpan={2}>Card details</th>
               <th>Available</th>
@@ -201,6 +201,7 @@ function SellManagement(): JSX.Element {
                       handleCheck(i);
                     }}
                     checked={data[i].selected}
+                    color="info"
                   />
                 </td>
                 <td className="text-center w-[110px]">

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -78,6 +78,10 @@ function SellManagement(): JSX.Element {
   }
 
   function handleCheck(index: number) {
+    if (data[index].selected) {
+      setCheckedAll(false);
+    }
+
     dispatch({
       type: data[index].selected ? 'deselect' : 'select',
       index,

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -193,7 +193,7 @@ function SellManagement(): JSX.Element {
     }
   }, [user.user_id, page]);
   return (
-    <section>
+    <section className="bg-[#F5F5F5] min-h-[100vh]">
       <PageHeader heading="Sell">
         {/* TO-DO: update URL */}
         <Button href="/listing/new" variant="outlined" color="success">
@@ -287,7 +287,7 @@ function SellManagement(): JSX.Element {
           </div>
         </div>
         <Pagination
-          className="self-center"
+          className="self-center justify-self-end"
           page={page}
           onChange={(e, p) => {
             e.preventDefault();

--- a/frontend/src/pages/yugioh/SellManagement.tsx
+++ b/frontend/src/pages/yugioh/SellManagement.tsx
@@ -7,6 +7,7 @@ import { useAuthenticationStatus, useCurrentUser } from '../../context/user';
 import YugiohCardConditionLabel from '../../components/yugioh/YugiohCardConditionLabel';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import PageHeader from '../../components/PageHeader';
+import LensIcon from '@mui/icons-material/Lens';
 
 type ListingData = {
   listing: YugiohCardListing;
@@ -271,8 +272,14 @@ function SellManagement(): JSX.Element {
             <Button variant="outlined" color="error" onClick={deleteAll}>
               Delete all
             </Button>
-            <Button variant="outlined" onClick={openMenu}>
-              . . .
+            <Button
+              className="font-bold flex gap-1 items-center justify-center"
+              variant="outlined"
+              onClick={openMenu}
+            >
+              <LensIcon sx={{ fontSize: 6 }} color="secondary" />
+              <LensIcon sx={{ fontSize: 6 }} color="secondary" />
+              <LensIcon sx={{ fontSize: 6 }} color="secondary" />
             </Button>
             <Menu open={open} anchorEl={anchorEl} onClose={closeMenu}>
               <MenuItem disabled={data.every((d) => !d.selected)} onClick={deleteSelectedItems}>

--- a/frontend/src/router/Router.tsx
+++ b/frontend/src/router/Router.tsx
@@ -12,6 +12,7 @@ import YugiohCardDetails from '../pages/yugioh/YugiohCardDetails';
 import { loadCardDetails } from './loadCardDetails/loadCardDetails';
 import Search from '../pages/Search';
 import { loadSearchResults } from './loadSearchResults/loadSearchResults';
+import SellManagement from '../pages/yugioh/SellManagement';
 
 const routes = createBrowserRouter([
   {
@@ -78,6 +79,15 @@ const routes = createBrowserRouter([
                 element: <YugiohCardDetails />,
               },
             ],
+          },
+        ],
+      },
+      {
+        path: 'sell',
+        children: [
+          {
+            path: 'manage',
+            element: <SellManagement />,
           },
         ],
       },

--- a/frontend/src/router/Router.tsx
+++ b/frontend/src/router/Router.tsx
@@ -88,6 +88,7 @@ const routes = createBrowserRouter([
           {
             path: 'manage',
             element: <SellManagement />,
+            loader: authorizedGuard,
           },
         ],
       },

--- a/frontend/src/services/yugioh/yugiohService.ts
+++ b/frontend/src/services/yugioh/yugiohService.ts
@@ -55,4 +55,12 @@ export const yugiohService = {
 
     return cards!;
   },
+
+  async editListing(listing: YugiohCardListing): Promise<YugiohCardListing> {
+    const result = await httpService.put<YugiohCardListing>(
+      api.yugioh.listing.id(listing.id),
+      listing,
+    );
+    return result!;
+  },
 };

--- a/frontend/src/services/yugioh/yugiohService.ts
+++ b/frontend/src/services/yugioh/yugiohService.ts
@@ -30,6 +30,18 @@ export const yugiohService = {
     return listings!;
   },
 
+  async getCardListingsByUserId(id: number, page = 1): Promise<PaginatedItem<YugiohCardListing>> {
+    const listings = await httpService.get<PaginatedItem<YugiohCardListing>>(
+      api.yugioh.listing.root,
+      {
+        page,
+        user_id: id,
+      },
+    );
+
+    return listings!;
+  },
+
   async buyCardListing(id: number, listing: BuyYugiohCardListing): Promise<YugiohCardListing> {
     const data = await httpService.put<YugiohCardListing>(api.yugioh.listing.buyById(id), listing);
     return data!;

--- a/frontend/src/services/yugioh/yugiohService.ts
+++ b/frontend/src/services/yugioh/yugiohService.ts
@@ -63,4 +63,8 @@ export const yugiohService = {
     );
     return result!;
   },
+
+  async deleteListingById(id: number): Promise<void> {
+    await httpService.del(api.yugioh.listing.id(id));
+  },
 };


### PR DESCRIPTION
This PR implements the sell management page, which is entirely functional. There are a few notes, though:
- the pagination differs from the wireframe for consistency with the other pages that use similar tables and to save time
- the "Delist all" and "Deselect all" buttons will perform the respective operations on all listings on the current page, regardless of whether they've been selected or not. The third button opens more options, which includes performing the actions on the selected items. Some of those options are also disabled when appropriate.
- since the branch for CF-20 is not published at the time this PR was opened, I resorted to creating the CRUD service methods I needed in this PR, this may result in a conflict or two (due to this, I've also opted not to include unit tests for the time being). Likewise, client URLs are not included / may not match with the ones used there and will require updating at some point