### PR TITLE
Allow the user to make the changes to their profile on the front end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Avatars
+backend/media

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,7 +59,7 @@ function App() {
         .then(async (jwt) => {
           localStorage.setItem('accessToken', jwt);
           const { user_id } = userService.extractUserFromToken(jwt);
-          const user = await userService.getUser(user_id);
+          const user = await userService.getUserById(user_id);
 
           setUser({ user_id, ...user });
         })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,10 +56,12 @@ function App() {
     if (refreshToken && accessToken) {
       userService
         .verifySession(refreshToken)
-        .then((jwt) => {
-          const user = userService.extractUserFromToken(jwt);
-          setUser(user);
+        .then(async (jwt) => {
           localStorage.setItem('accessToken', jwt);
+          const { user_id } = userService.extractUserFromToken(jwt);
+          const user = await userService.getUser(user_id);
+
+          setUser({ user_id, ...user });
         })
         .catch((res) => {
           if (res instanceof HttpError && res.err.status < 500) {

--- a/frontend/src/components/auth/AuthForm.tsx
+++ b/frontend/src/components/auth/AuthForm.tsx
@@ -1,7 +1,12 @@
 import React, { useRef } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { userService } from '../../services/user/user';
-import { UserLogin, UserRegister } from '../../services/user/types';
+import {
+  SuccessfulAuthenticationResponse,
+  UserLogin,
+  UserRegister,
+} from '../../services/user/types';
+import { useCurrentUser } from '../../context/user';
 
 type AuthFormProps = {
   isLogin: boolean;
@@ -14,10 +19,12 @@ type ErrorProps = {
 };
 
 const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
-  async function authenticaticateUser(loginData: UserLogin) {
-    const data = await userService.login(loginData);
-    localStorage.setItem('accessToken', data.access);
-    localStorage.setItem('refreshToken', data.refresh);
+  const { setUser } = useCurrentUser();
+  async function authenticaticateUser(id: number, tokens: SuccessfulAuthenticationResponse) {
+    localStorage.setItem('accessToken', tokens.access);
+    localStorage.setItem('refreshToken', tokens.refresh);
+    const data = await userService.getUser(id);
+    setUser({ user_id: id, ...data });
     navigate('/');
   }
 
@@ -50,21 +57,24 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
     event.preventDefault();
     validate(isLogin);
     try {
+      let tokens: SuccessfulAuthenticationResponse;
       const loginData: UserLogin = {
         username: usernameRef.current!.value,
         password: passwordRef.current!.value,
       };
       if (isLogin) {
-        authenticaticateUser(loginData);
+        tokens = await userService.login(loginData);
       } else {
         const formData: UserRegister = {
           email: emailRef.current!.value,
           password: passwordRef.current!.value,
           username: usernameRef.current!.value,
         };
-        await userService.register(formData);
-        authenticaticateUser(loginData);
+        tokens = await userService.register(formData);
       }
+
+      const payload = userService.extractUserFromToken(tokens.access);
+      await authenticaticateUser(payload.user_id, tokens);
     } catch (error: any) {
       const data = await error.err.json();
       setError(data);

--- a/frontend/src/components/auth/AuthForm.tsx
+++ b/frontend/src/components/auth/AuthForm.tsx
@@ -23,7 +23,7 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
   async function authenticaticateUser(id: number, tokens: SuccessfulAuthenticationResponse) {
     localStorage.setItem('accessToken', tokens.access);
     localStorage.setItem('refreshToken', tokens.refresh);
-    const data = await userService.getUser(id);
+    const data = await userService.getUserById(id);
     setUser({ user_id: id, ...data });
     navigate('/');
   }

--- a/frontend/src/components/navigation/desktop/DesktopLoggedInNav.tsx
+++ b/frontend/src/components/navigation/desktop/DesktopLoggedInNav.tsx
@@ -3,6 +3,7 @@ import ProfilePictureAvatar from '../profilePictureAvatar/ProfilePictureAvatar';
 import NewActionButton from './buttons/NewActionButton';
 import NotificationButton from './buttons/NotificationButton';
 import { useLogout } from '../../../util/useLogout';
+import { useCurrentUser } from '../../../context/user';
 
 /**
  * A list of navigation items for logged in users.
@@ -11,6 +12,7 @@ import { useLogout } from '../../../util/useLogout';
  */
 function DesktopLoggedInNav(): JSX.Element {
   const logout = useLogout();
+  const { user } = useCurrentUser();
 
   return (
     <ul className="list-none flex gap-4 items-center">
@@ -21,7 +23,7 @@ function DesktopLoggedInNav(): JSX.Element {
         <NotificationButton />
       </li>
       <li>
-        <ProfilePictureAvatar />
+        <ProfilePictureAvatar imageUrl={user.avatar} />
       </li>
       <li>
         <Button onClick={logout} color="primary" variant="outlined">

--- a/frontend/src/components/navigation/mobile/menus/MobileLoggedInNav.tsx
+++ b/frontend/src/components/navigation/mobile/menus/MobileLoggedInNav.tsx
@@ -84,7 +84,7 @@ function MobileLoggedInNav(props: MobileLoggedInNavProps): JSX.Element {
       <ListItem disablePadding>
         <ListItemButton href={`/user/${user.username}/settings`}>
           <ListItemAvatar>
-            <Avatar sx={{ width: 24, height: 24 }} src="#" />
+            <Avatar sx={{ width: 24, height: 24 }} src={user.avatar || ''} />
           </ListItemAvatar>
           <ListItemText primary="My profile" />
         </ListItemButton>

--- a/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.tsx
+++ b/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.tsx
@@ -2,7 +2,7 @@ import { Avatar, Link } from '@mui/material';
 import { useCurrentUser } from '../../../context/user';
 
 type ProfilePictureAvatar = {
-  imageUrl?: string;
+  imageUrl: string | null;
 };
 
 /**
@@ -15,7 +15,7 @@ function ProfilePictureAvatar(props: ProfilePictureAvatar): JSX.Element {
 
   return (
     <Link href={`/user/${user.username}/settings`}>
-      <Avatar src={props.imageUrl} />
+      <Avatar src={props.imageUrl || ''} />
     </Link>
   );
 }

--- a/frontend/src/components/profile/ProfilePublicData.tsx
+++ b/frontend/src/components/profile/ProfilePublicData.tsx
@@ -3,14 +3,19 @@ import TrophyIcon from '@mui/icons-material/EmojiEvents';
 import PageSection from '../PageSection';
 import YugiohSellerRankBadge from '../yugioh/seller/YugiohSellerRankBadge';
 import { sellerRankData } from '../../constants/sellerRank';
+import { PublicUserInfo } from '../../services/user/types';
 
-function ProfilePublicData(): JSX.Element {
+type ProfilePublicDataProps = {
+  user: PublicUserInfo;
+};
+
+function ProfilePublicData(props: ProfilePublicDataProps): JSX.Element {
   return (
     <PageSection className="text-center lg:text-left mb-8">
       <div className="pt-4 pb-4 lg:pl-12 lg:pr-12 flex flex-col-reverse lg:justify-between lg:flex-row">
         <div className="self-center">
           <h2 className="font-bold text-2xl mb-2 flex gap-4 items-center">
-            @TheAverageTCGEnjoyer
+            @{props.user.username}
             <Tooltip
               title={sellerRankData.renowned.tooltipText}
               arrow
@@ -27,7 +32,7 @@ function ProfilePublicData(): JSX.Element {
           </Typography>
         </div>
         <div className="flex justify-center lg:block">
-          <Avatar src="#" sx={{ width: 80, height: 80 }} />
+          <Avatar src={props.user.avatar} sx={{ width: 80, height: 80 }} />
         </div>
       </div>
       <Divider sx={{ width: '90%', margin: '0 auto' }} />

--- a/frontend/src/components/profile/ProfilePublicData.tsx
+++ b/frontend/src/components/profile/ProfilePublicData.tsx
@@ -8,7 +8,7 @@ function ProfilePublicData(): JSX.Element {
   return (
     <PageSection className="text-center lg:text-left mb-8">
       <div className="pt-4 pb-4 lg:pl-12 lg:pr-12 flex flex-col-reverse lg:justify-between lg:flex-row">
-        <div>
+        <div className="self-center">
           <h2 className="font-bold text-2xl mb-2 flex gap-4 items-center">
             @TheAverageTCGEnjoyer
             <Tooltip

--- a/frontend/src/components/profile/profileSettings/DeleteAccount.tsx
+++ b/frontend/src/components/profile/profileSettings/DeleteAccount.tsx
@@ -2,7 +2,11 @@ import { Button, useTheme } from '@mui/material';
 import PageSection from '../../PageSection';
 import ProfileSectionFooter from '../ProfileSectionFooter';
 
-function DeleteAccount(): JSX.Element {
+type DeleteAccountProps = {
+  onDelete: () => void;
+};
+
+function DeleteAccount(props: DeleteAccountProps): JSX.Element {
   const theme = useTheme();
   return (
     <PageSection borderColor={theme.palette.error.light}>
@@ -15,7 +19,7 @@ function DeleteAccount(): JSX.Element {
       </div>
       <ProfileSectionFooter backgroundColor="red">
         <p>We will definitely miss you...</p>
-        <Button color="error" variant="contained" className="inline-block">
+        <Button onClick={props.onDelete} color="error" variant="contained" className="inline-block">
           Delete Account
         </Button>
       </ProfileSectionFooter>

--- a/frontend/src/components/profile/profileSettings/EmailSettings.tsx
+++ b/frontend/src/components/profile/profileSettings/EmailSettings.tsx
@@ -1,10 +1,11 @@
 import { Button, TextField } from '@mui/material';
 import PageSection from '../../PageSection';
 import ProfileSectionFooter from '../ProfileSectionFooter';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, FormEvent, useState } from 'react';
 
 type EmailSettingsProps = {
   email: string;
+  onSubmit: (email: string) => void;
 };
 
 function EmailSettings(props: EmailSettingsProps): JSX.Element {
@@ -19,19 +20,32 @@ function EmailSettings(props: EmailSettingsProps): JSX.Element {
     setEmail(value);
   }
 
+  function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    props.onSubmit(email);
+  }
+
   return (
     <PageSection>
-      <div className="pt-4 pb-4 lg:pl-12 lg:pr-12">
-        <h2 className="font-bold mb-4 text-lg">Email</h2>
-        <p className="mb-4">Please enter your email address.</p>
-        <TextField value={email} onChange={handleEmailChange} size="small" />
-      </div>
-      <ProfileSectionFooter>
-        <p>We will email you to verify the change.</p>
-        <Button disabled={isInvalid} color="primary" variant="contained" className="inline-block">
-          Save
-        </Button>
-      </ProfileSectionFooter>
+      <form onSubmit={handleSubmit}>
+        <div className="pt-4 pb-4 lg:pl-12 lg:pr-12">
+          <h2 className="font-bold mb-4 text-lg">Email</h2>
+          <p className="mb-4">Please enter your email address.</p>
+          <TextField value={email} onChange={handleEmailChange} size="small" />
+        </div>
+        <ProfileSectionFooter>
+          <p>You will be logged out after the change.</p>
+          <Button
+            type="submit"
+            disabled={isInvalid}
+            color="primary"
+            variant="contained"
+            className="inline-block"
+          >
+            Save
+          </Button>
+        </ProfileSectionFooter>
+      </form>
     </PageSection>
   );
 }

--- a/frontend/src/components/profile/profileSettings/ShipmentAddressSettings.tsx
+++ b/frontend/src/components/profile/profileSettings/ShipmentAddressSettings.tsx
@@ -1,10 +1,15 @@
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, FormEvent, useState } from 'react';
 import PageSection from '../../PageSection';
 import ProfileSectionFooter from '../ProfileSectionFooter';
 import { Button, TextField } from '@mui/material';
 
-function ShipmentAddressSettings(): JSX.Element {
-  const [address, setAddress] = useState('');
+type ShipmentAddressSettingsProps = {
+  address: string | null;
+  onSubmit: (address: string) => void;
+};
+
+function ShipmentAddressSettings(props: ShipmentAddressSettingsProps): JSX.Element {
+  const [address, setAddress] = useState(props.address || '');
 
   function handleAddressChange(event: ChangeEvent<HTMLInputElement>) {
     event.preventDefault();
@@ -12,24 +17,32 @@ function ShipmentAddressSettings(): JSX.Element {
     setAddress(value);
   }
 
+  function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    props.onSubmit(address);
+  }
+
   return (
     <PageSection>
-      <div className="pt-4 pb-4 lg:pl-12 lg:pr-12">
-        <h2 className="font-bold mb-4 text-lg">Default shipment address</h2>
-        <p className="mb-4">Enter the default shipment address that will get pre-filled.</p>
-        <TextField value={address} onChange={handleAddressChange} size="small" />
-      </div>
-      <ProfileSectionFooter>
-        <p>You can always change the address per purchase in the checkout section.</p>
-        <Button
-          disabled={address === ''}
-          color="primary"
-          variant="contained"
-          className="inline-block"
-        >
-          Save
-        </Button>
-      </ProfileSectionFooter>
+      <form onSubmit={handleSubmit}>
+        <div className="pt-4 pb-4 lg:pl-12 lg:pr-12">
+          <h2 className="font-bold mb-4 text-lg">Default shipment address</h2>
+          <p className="mb-4">Enter the default shipment address that will get pre-filled.</p>
+          <TextField value={address} onChange={handleAddressChange} size="small" />
+        </div>
+        <ProfileSectionFooter>
+          <p>You can always change the address per purchase in the checkout section.</p>
+          <Button
+            disabled={address === '' || address === props.address}
+            color="primary"
+            variant="contained"
+            className="inline-block"
+            type="submit"
+          >
+            Save
+          </Button>
+        </ProfileSectionFooter>
+      </form>
     </PageSection>
   );
 }

--- a/frontend/src/components/profile/profileSettings/avatarSettings/AvatarSettings.tsx
+++ b/frontend/src/components/profile/profileSettings/avatarSettings/AvatarSettings.tsx
@@ -1,6 +1,6 @@
 import { Avatar, Button, Typography, styled, useTheme } from '@mui/material';
 import PageSection from '../../../PageSection';
-import { useState } from 'react';
+import { FormEvent, useState } from 'react';
 import { handleAvatarUpload } from './handleAvatarUpload';
 import ProfileSectionFooter from '../../ProfileSectionFooter';
 
@@ -18,11 +18,13 @@ const VisuallyHiddenInput = styled('input')({
 
 type AvatarSettingsProps = {
   avatar: string | null;
+  onSubmit: (avatar: File) => void;
 };
 
 function AvatarSettings(props: AvatarSettingsProps): JSX.Element {
   const [imageUpload, setImageUpload] = useState(props.avatar || '');
   const [imageError, setImageError] = useState('');
+  const [file, setFile] = useState<File>();
   const [hasSelected, setSelected] = useState(false);
 
   const theme = useTheme();
@@ -36,6 +38,7 @@ function AvatarSettings(props: AvatarSettingsProps): JSX.Element {
         .then((result) => {
           setImageError('');
           setImageUpload(result);
+          setFile(file);
         })
         .catch((err) => {
           setImageError(err);
@@ -45,44 +48,58 @@ function AvatarSettings(props: AvatarSettingsProps): JSX.Element {
     }
   }
 
+  function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    if (file) {
+      props.onSubmit(file);
+    }
+  }
+
   return (
     <PageSection>
-      <div className="pt-4 pb-4 lg:pl-12 lg:pr-12 flex flex-col-reverse lg:justify-between lg:flex-row">
-        <div>
-          <h2 className="font-bold mb-4 text-lg">Avatar</h2>
-          <p>Select your avatar by clicking on the avatar circle.</p>
-          <Typography component="p" color={error} className={imageError ? 'visible' : 'invisible'}>
-            {imageError || 'Your file is valid!'}
-          </Typography>
+      <form onSubmit={handleSubmit}>
+        <div className="pt-4 pb-4 lg:pl-12 lg:pr-12 flex flex-col-reverse lg:justify-between lg:flex-row">
+          <div>
+            <h2 className="font-bold mb-4 text-lg">Avatar</h2>
+            <p>Select your avatar by clicking on the avatar circle.</p>
+            <Typography
+              component="p"
+              color={error}
+              className={imageError ? 'visible' : 'invisible'}
+            >
+              {imageError || 'Your file is valid!'}
+            </Typography>
+          </div>
+          <div className="relative flex flex-row mb-2 lg:mb-0 gap-4 flex-wrap justify-center lg:justify-normal">
+            <label>
+              <Avatar
+                className="cursor-pointer hover:opacity-50 z-10"
+                src={imageUpload}
+                sx={{ width: 80, height: 80 }}
+              />
+              <VisuallyHiddenInput
+                aria-label="Select an image to use as your avatar"
+                type="file"
+                onChange={changeAvatarPreview}
+                id="avatar"
+                accept="image/*"
+              />
+            </label>
+          </div>
         </div>
-        <div className="relative flex flex-row mb-2 lg:mb-0 gap-4 flex-wrap justify-center lg:justify-normal">
-          <label>
-            <Avatar
-              className="cursor-pointer hover:opacity-50 z-10"
-              src={imageUpload}
-              sx={{ width: 80, height: 80 }}
-            />
-            <VisuallyHiddenInput
-              aria-label="Select an image to use as your avatar"
-              type="file"
-              onChange={changeAvatarPreview}
-              id="avatar"
-              accept="image/*"
-            />
-          </label>
-        </div>
-      </div>
-      <ProfileSectionFooter>
-        <p>An avatar is optional but strongly recommended.</p>
-        <Button
-          disabled={!(imageError === '' && hasSelected)}
-          color="primary"
-          variant="contained"
-          className="inline-block"
-        >
-          Save
-        </Button>
-      </ProfileSectionFooter>
+        <ProfileSectionFooter>
+          <p>An avatar is optional but strongly recommended.</p>
+          <Button
+            disabled={!(imageError === '' && hasSelected)}
+            color="primary"
+            variant="contained"
+            className="inline-block"
+            type="submit"
+          >
+            Save
+          </Button>
+        </ProfileSectionFooter>
+      </form>
     </PageSection>
   );
 }

--- a/frontend/src/components/profile/profileSettings/avatarSettings/AvatarSettings.tsx
+++ b/frontend/src/components/profile/profileSettings/avatarSettings/AvatarSettings.tsx
@@ -19,13 +19,14 @@ const VisuallyHiddenInput = styled('input')({
 type AvatarSettingsProps = {
   avatar: string | null;
   onSubmit: (avatar: File) => void;
+  hasSelected: boolean;
+  onSelect: (selected: boolean) => void;
 };
 
 function AvatarSettings(props: AvatarSettingsProps): JSX.Element {
   const [imageUpload, setImageUpload] = useState(props.avatar || '');
   const [imageError, setImageError] = useState('');
   const [file, setFile] = useState<File>();
-  const [hasSelected, setSelected] = useState(false);
 
   const theme = useTheme();
   const error = theme.palette.error.main;
@@ -44,7 +45,7 @@ function AvatarSettings(props: AvatarSettingsProps): JSX.Element {
           setImageError(err);
           setImageUpload('');
         })
-        .finally(() => setSelected(true));
+        .finally(() => props.onSelect(true));
     }
   }
 
@@ -90,7 +91,7 @@ function AvatarSettings(props: AvatarSettingsProps): JSX.Element {
         <ProfileSectionFooter>
           <p>An avatar is optional but strongly recommended.</p>
           <Button
-            disabled={!(imageError === '' && hasSelected)}
+            disabled={!(imageError === '' && props.hasSelected)}
             color="primary"
             variant="contained"
             className="inline-block"

--- a/frontend/src/components/profile/profileSettings/avatarSettings/AvatarSettings.tsx
+++ b/frontend/src/components/profile/profileSettings/avatarSettings/AvatarSettings.tsx
@@ -16,8 +16,12 @@ const VisuallyHiddenInput = styled('input')({
   width: 1,
 });
 
-function AvatarSettings(): JSX.Element {
-  const [imageUpload, setImageUpload] = useState('');
+type AvatarSettingsProps = {
+  avatar: string | null;
+};
+
+function AvatarSettings(props: AvatarSettingsProps): JSX.Element {
+  const [imageUpload, setImageUpload] = useState(props.avatar || '');
   const [imageError, setImageError] = useState('');
   const [hasSelected, setSelected] = useState(false);
 

--- a/frontend/src/components/profile/profileSettings/avatarSettings/handleAvatarUpload.ts
+++ b/frontend/src/components/profile/profileSettings/avatarSettings/handleAvatarUpload.ts
@@ -22,7 +22,7 @@ export const handleAvatarUpload = async (file: File) =>
     fileReader.onload = () => {
       const result = fileReader.result;
       if (result) {
-        return resolve(result.toString());
+        return resolve(result as string);
       } else {
         return reject(errorMessages.uploadFailed);
       }

--- a/frontend/src/components/profile/profileSettings/usernameSettings/UsernameSettings.tsx
+++ b/frontend/src/components/profile/profileSettings/usernameSettings/UsernameSettings.tsx
@@ -2,12 +2,13 @@ import { Button, TextField } from '@mui/material';
 import PageSection from '../../../PageSection';
 import ProfileSectionFooter from '../../ProfileSectionFooter';
 import './UsernameSettings.css';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, FormEvent, useState } from 'react';
 
 const maxLength = 48;
 
 type UsernameSettingsProps = {
   username: string;
+  onSubmit: (username: string) => void;
 };
 
 function UsernameSettings(props: UsernameSettingsProps): JSX.Element {
@@ -23,41 +24,52 @@ function UsernameSettings(props: UsernameSettingsProps): JSX.Element {
     }
   }
 
+  function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    props.onSubmit(username);
+  }
+
   return (
     <PageSection>
-      <div className="pt-4 pb-4 lg:pl-12 lg:pr-12">
-        <div>
-          <h2 className="font-bold mb-4 text-lg">Username</h2>
-          <p className="mb-4">This is how people will recognize you.</p>
+      <form onSubmit={handleSubmit}>
+        <div className="pt-4 pb-4 lg:pl-12 lg:pr-12">
           <div>
-            <TextField
-              className="user-url-field sm:w-[165px]"
-              size="small"
-              sx={{ backgroundColor: '#F5F5F5' }}
-              disabled
-              value="cardflow.com/user/"
-            />
-            <TextField
-              className="username-field"
-              size="small"
-              value={username}
-              onChange={handleUsernameChange}
-              helperText={`${username.length} / ${maxLength}`}
-            />
+            <h2 className="font-bold mb-4 text-lg">Username</h2>
+            <p className="mb-4">This is how people will recognize you.</p>
+            <div>
+              <TextField
+                className="user-url-field sm:w-[165px]"
+                size="small"
+                sx={{ backgroundColor: '#F5F5F5' }}
+                disabled
+                value="cardflow.com/user/"
+              />
+              <TextField
+                className="username-field"
+                size="small"
+                value={username}
+                onChange={handleUsernameChange}
+                helperText={`${username.length} / ${maxLength}`}
+              />
+            </div>
           </div>
         </div>
-      </div>
-      <ProfileSectionFooter>
-        <p>Please use {maxLength} characters at maximum.</p>
-        <Button
-          disabled={username === '' || username === props.username}
-          color="primary"
-          variant="contained"
-          className="inline-block"
-        >
-          Save
-        </Button>
-      </ProfileSectionFooter>
+        <ProfileSectionFooter>
+          <p>
+            Please use {maxLength} characters at maximum. You will be logged out after changing your
+            username
+          </p>
+          <Button
+            disabled={username === '' || username === props.username}
+            color="primary"
+            variant="contained"
+            className="inline-block"
+            type="submit"
+          >
+            Save
+          </Button>
+        </ProfileSectionFooter>
+      </form>
     </PageSection>
   );
 }

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -9,7 +9,8 @@ export const api = Object.freeze({
     refresh: `${accounts}/refresh/`,
     register: `${accounts}/register/`,
     login: `${accounts}/login/`,
-    user: (id: string | number) => `${accounts}/user/${id}/`,
+    user: `${accounts}/user/`,
+    userById: (id: string | number) => `${accounts}/user/${id}/`,
   },
   yugioh: {
     listing: {

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -9,6 +9,7 @@ export const api = Object.freeze({
     refresh: `${accounts}/refresh/`,
     register: `${accounts}/register/`,
     login: `${accounts}/login/`,
+    user: (id: string | number) => `${accounts}/user/${id}`,
   },
   yugioh: {
     listing: {

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -9,7 +9,7 @@ export const api = Object.freeze({
     refresh: `${accounts}/refresh/`,
     register: `${accounts}/register/`,
     login: `${accounts}/login/`,
-    user: (id: string | number) => `${accounts}/user/${id}`,
+    user: (id: string | number) => `${accounts}/user/${id}/`,
   },
   yugioh: {
     listing: {

--- a/frontend/src/context/user.tsx
+++ b/frontend/src/context/user.tsx
@@ -12,6 +12,12 @@ const UserContext = React.createContext<CurrentUserContext>({
     user_id: 0,
     email: '',
     username: '',
+    shipping_address: '',
+    first_name: null,
+    last_name: null,
+    phone_number: null,
+    city: null,
+    avatar: null,
   },
   setUser(user) {
     this.user = user;
@@ -21,6 +27,12 @@ const UserContext = React.createContext<CurrentUserContext>({
       user_id: 0,
       username: '',
       email: '',
+      shipping_address: null,
+      first_name: null,
+      last_name: null,
+      phone_number: null,
+      city: null,
+      avatar: null,
     };
   },
 });
@@ -30,6 +42,12 @@ export function UserContextProvider({ children }: { children: React.ReactNode })
     user_id: 0,
     username: '',
     email: '',
+    shipping_address: null,
+    first_name: null,
+    last_name: null,
+    phone_number: null,
+    city: null,
+    avatar: null,
   });
 
   function restartUser() {
@@ -37,6 +55,12 @@ export function UserContextProvider({ children }: { children: React.ReactNode })
       user_id: 0,
       username: '',
       email: '',
+      shipping_address: null,
+      first_name: null,
+      last_name: null,
+      phone_number: null,
+      city: null,
+      avatar: null,
     });
   }
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -2,29 +2,14 @@ import { Button } from '@mui/material';
 import Logo from '../components/logo/Logo';
 import { useTheme } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
-import { useAuthenticationStatus, useCurrentUser } from '../context/user';
-import { userService } from '../services/user/user';
-import { useEffect } from 'react';
+import { useAuthenticationStatus } from '../context/user';
 
 function Home(): JSX.Element {
   const theme = useTheme();
   const secondary = theme.palette.grey['900'];
   const secondaryTextColor = theme.palette.text.secondary;
   const navigate = useNavigate();
-  const { setUser } = useCurrentUser();
   const { isAuthenticated } = useAuthenticationStatus();
-  useEffect(() => {
-    const initializeAuth = async () => {
-      const refreshToken = localStorage.getItem('refreshToken');
-      if (refreshToken) {
-        const accessToken = await userService.verifySession(refreshToken);
-        const user = userService.extractUserFromToken(accessToken);
-        setUser(user);
-      }
-    };
-
-    initializeAuth();
-  }, [setUser]);
 
   return (
     <div className="flex justify-center items-center flex-col">

--- a/frontend/src/pages/profile/ProfilePublicInfoPage.tsx
+++ b/frontend/src/pages/profile/ProfilePublicInfoPage.tsx
@@ -1,12 +1,16 @@
 import ProfilePublicData from '../../components/profile/ProfilePublicData';
 import ProfileMarketActivity from '../../components/profile/profileMarketActivity/ProfileMarketActivity';
 import ProfilePage from '../../components/profile/ProfilePage';
+import { useLoaderData } from 'react-router-dom';
+import { UserAccountLoader } from '../../services/user/types';
 
 function ProfilePublicInfoPage(): JSX.Element {
+  const results = useLoaderData() as UserAccountLoader;
+  const user = results.data;
   return (
     <ProfilePage className="bg-[#F5F5F5]">
       <div className="flex flex-col gap-2">
-        <ProfilePublicData />
+        <ProfilePublicData user={user} />
         <ProfileMarketActivity />
       </div>
     </ProfilePage>

--- a/frontend/src/pages/profile/ProfileSettingsPage.tsx
+++ b/frontend/src/pages/profile/ProfileSettingsPage.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import ProfilePage from '../../components/profile/ProfilePage';
 import AvatarSettings from '../../components/profile/profileSettings/avatarSettings/AvatarSettings';
 import DeleteAccount from '../../components/profile/profileSettings/DeleteAccount';
@@ -8,41 +7,27 @@ import UsernameSettings from '../../components/profile/profileSettings/usernameS
 import { useCurrentUser } from '../../context/user';
 import { UserAccount } from '../../services/user/types';
 import { userService } from '../../services/user/user';
-import { useEffectAfterInitialLoad } from '../../util/useEffectAfterInitialLoad';
 import { useLogout } from '../../util/useLogout';
 
 function ProfileSettingsPage(): JSX.Element {
-  const { user } = useCurrentUser();
+  const { user, setUser } = useCurrentUser();
   const logout = useLogout();
-  const [userData, setUserData] = useState<UserAccount>({
-    username: '',
-    password: '',
-    email: '',
-    first_name: null,
-    last_name: null,
-    phone_number: null,
-    city: null,
-    shipping_address: null,
-    avatar: null,
-  });
 
-  function updateAccount(section: keyof UserAccount, data: string) {
+  async function updateAccount(section: keyof UserAccount, data: string) {
     const payload: Partial<UserAccount> = { [section]: data };
-    return userService.updateUser(user.user_id, payload).then(setUserData);
+    return userService.updateUser(user.user_id, payload).then((data) => {
+      setUser({ user_id: user.user_id, ...data });
+    });
   }
 
   function updateAndLogout(field: 'username' | 'email', value: string) {
     updateAccount(field, value).then(logout);
   }
 
-  useEffectAfterInitialLoad(() => {
-    userService.getUser(user.user_id).then(setUserData);
-  }, []);
-
   return (
     <ProfilePage className="bg-[#F5F5F5]">
       <div className="flex flex-col gap-8">
-        <AvatarSettings avatar={userData?.avatar?.toString() || ''} />
+        <AvatarSettings avatar={user.avatar?.toString() || ''} />
         <UsernameSettings
           onSubmit={(u) => updateAndLogout('username', u)}
           key={user.username + '1'}

--- a/frontend/src/pages/profile/ProfileSettingsPage.tsx
+++ b/frontend/src/pages/profile/ProfileSettingsPage.tsx
@@ -32,8 +32,9 @@ function ProfileSettingsPage(): JSX.Element {
   }
 
   function updateAvatar(avatar: File) {
-    userService.updateUserAvatar(user.user_id, avatar).then(() => {
+    userService.updateUserAvatar(user.user_id, avatar).then((data) => {
       setSelectedAvatar(false);
+      setUser({ user_id: user.user_id, ...data });
     });
   }
 

--- a/frontend/src/pages/profile/ProfileSettingsPage.tsx
+++ b/frontend/src/pages/profile/ProfileSettingsPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import ProfilePage from '../../components/profile/ProfilePage';
 import AvatarSettings from '../../components/profile/profileSettings/avatarSettings/AvatarSettings';
 import DeleteAccount from '../../components/profile/profileSettings/DeleteAccount';
@@ -12,6 +13,8 @@ import { useLogout } from '../../util/useLogout';
 function ProfileSettingsPage(): JSX.Element {
   const { user, setUser } = useCurrentUser();
   const logout = useLogout();
+
+  const [hasSelectedAnAvatar, setSelectedAvatar] = useState(false);
 
   async function updateAccount(section: keyof UserAccount, data: string) {
     const payload: Partial<UserAccount> = { [section]: data };
@@ -29,13 +32,21 @@ function ProfileSettingsPage(): JSX.Element {
   }
 
   function updateAvatar(avatar: File) {
-    userService.updateUserAvatar(user.user_id, avatar);
+    userService.updateUserAvatar(user.user_id, avatar).then(() => {
+      setSelectedAvatar(false);
+    });
   }
 
   return (
     <ProfilePage className="bg-[#F5F5F5]">
       <div className="flex flex-col gap-8">
-        <AvatarSettings key={user?.avatar + '0'} avatar={user.avatar} onSubmit={updateAvatar} />
+        <AvatarSettings
+          hasSelected={hasSelectedAnAvatar}
+          onSelect={setSelectedAvatar}
+          key={user?.avatar + '0'}
+          avatar={user.avatar}
+          onSubmit={updateAvatar}
+        />
         <UsernameSettings
           onSubmit={(u) => updateAndLogout('username', u)}
           key={user.username + '1'}

--- a/frontend/src/pages/profile/ProfileSettingsPage.tsx
+++ b/frontend/src/pages/profile/ProfileSettingsPage.tsx
@@ -28,10 +28,14 @@ function ProfileSettingsPage(): JSX.Element {
     userService.deleteUser(user.user_id).then(logout);
   }
 
+  function updateAvatar(avatar: File) {
+    userService.updateUserAvatar(user.user_id, avatar);
+  }
+
   return (
     <ProfilePage className="bg-[#F5F5F5]">
       <div className="flex flex-col gap-8">
-        <AvatarSettings avatar={user.avatar?.toString() || ''} />
+        <AvatarSettings key={user?.avatar + '0'} avatar={user.avatar} onSubmit={updateAvatar} />
         <UsernameSettings
           onSubmit={(u) => updateAndLogout('username', u)}
           key={user.username + '1'}

--- a/frontend/src/pages/profile/ProfileSettingsPage.tsx
+++ b/frontend/src/pages/profile/ProfileSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import ProfilePage from '../../components/profile/ProfilePage';
 import AvatarSettings from '../../components/profile/profileSettings/avatarSettings/AvatarSettings';
 import DeleteAccount from '../../components/profile/profileSettings/DeleteAccount';
@@ -8,10 +8,12 @@ import UsernameSettings from '../../components/profile/profileSettings/usernameS
 import { useCurrentUser } from '../../context/user';
 import { UserAccount } from '../../services/user/types';
 import { userService } from '../../services/user/user';
+import { useEffectAfterInitialLoad } from '../../util/useEffectAfterInitialLoad';
+import { useLogout } from '../../util/useLogout';
 
 function ProfileSettingsPage(): JSX.Element {
   const { user } = useCurrentUser();
-
+  const logout = useLogout();
   const [userData, setUserData] = useState<UserAccount>({
     username: '',
     password: '',
@@ -24,15 +26,28 @@ function ProfileSettingsPage(): JSX.Element {
     avatar: null,
   });
 
-  useEffect(() => {
+  function updateAccount(section: keyof UserAccount, data: string) {
+    const payload: Partial<UserAccount> = { [section]: data };
+    return userService.updateUser(user.user_id, payload).then(setUserData);
+  }
+
+  function updateUsername(username: string) {
+    updateAccount('username', username).then(logout);
+  }
+
+  useEffectAfterInitialLoad(() => {
     userService.getUser(user.user_id).then(setUserData);
   }, []);
 
   return (
     <ProfilePage className="bg-[#F5F5F5]">
       <div className="flex flex-col gap-8">
-        <AvatarSettings avatar={userData?.avatar} />
-        <UsernameSettings key={user.username + '1'} username={user.username} />
+        <AvatarSettings avatar={userData?.avatar?.toString() || ''} />
+        <UsernameSettings
+          onSubmit={updateUsername}
+          key={user.username + '1'}
+          username={user.username}
+        />
         <EmailSettings key={user.email + '2'} email={user.email} />
         <ShipmentAddressSettings />
         <DeleteAccount />

--- a/frontend/src/pages/profile/ProfileSettingsPage.tsx
+++ b/frontend/src/pages/profile/ProfileSettingsPage.tsx
@@ -24,6 +24,10 @@ function ProfileSettingsPage(): JSX.Element {
     updateAccount(field, value).then(logout);
   }
 
+  function deleteAccount() {
+    userService.deleteUser(user.user_id).then(logout);
+  }
+
   return (
     <ProfilePage className="bg-[#F5F5F5]">
       <div className="flex flex-col gap-8">
@@ -43,7 +47,7 @@ function ProfileSettingsPage(): JSX.Element {
           onSubmit={(a) => updateAccount('shipping_address', a)}
           key={user.shipping_address + '3'}
         />
-        <DeleteAccount />
+        <DeleteAccount onDelete={deleteAccount} />
       </div>
     </ProfilePage>
   );

--- a/frontend/src/pages/profile/ProfileSettingsPage.tsx
+++ b/frontend/src/pages/profile/ProfileSettingsPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import ProfilePage from '../../components/profile/ProfilePage';
 import AvatarSettings from '../../components/profile/profileSettings/avatarSettings/AvatarSettings';
 import DeleteAccount from '../../components/profile/profileSettings/DeleteAccount';
@@ -5,14 +6,32 @@ import EmailSettings from '../../components/profile/profileSettings/EmailSetting
 import ShipmentAddressSettings from '../../components/profile/profileSettings/ShipmentAddressSettings';
 import UsernameSettings from '../../components/profile/profileSettings/usernameSettings/UsernameSettings';
 import { useCurrentUser } from '../../context/user';
+import { UserAccount } from '../../services/user/types';
+import { userService } from '../../services/user/user';
 
 function ProfileSettingsPage(): JSX.Element {
   const { user } = useCurrentUser();
 
+  const [userData, setUserData] = useState<UserAccount>({
+    username: '',
+    password: '',
+    email: '',
+    first_name: null,
+    last_name: null,
+    phone_number: null,
+    city: null,
+    shipping_address: null,
+    avatar: null,
+  });
+
+  useEffect(() => {
+    userService.getUser(user.user_id).then(setUserData);
+  }, []);
+
   return (
     <ProfilePage className="bg-[#F5F5F5]">
       <div className="flex flex-col gap-8">
-        <AvatarSettings />
+        <AvatarSettings avatar={userData?.avatar} />
         <UsernameSettings key={user.username + '1'} username={user.username} />
         <EmailSettings key={user.email + '2'} email={user.email} />
         <ShipmentAddressSettings />

--- a/frontend/src/pages/profile/ProfileSettingsPage.tsx
+++ b/frontend/src/pages/profile/ProfileSettingsPage.tsx
@@ -38,7 +38,11 @@ function ProfileSettingsPage(): JSX.Element {
           key={user.email + '2'}
           email={user.email}
         />
-        <ShipmentAddressSettings />
+        <ShipmentAddressSettings
+          address={user.shipping_address}
+          onSubmit={(a) => updateAccount('shipping_address', a)}
+          key={user.shipping_address + '3'}
+        />
         <DeleteAccount />
       </div>
     </ProfilePage>

--- a/frontend/src/pages/profile/ProfileSettingsPage.tsx
+++ b/frontend/src/pages/profile/ProfileSettingsPage.tsx
@@ -31,8 +31,8 @@ function ProfileSettingsPage(): JSX.Element {
     return userService.updateUser(user.user_id, payload).then(setUserData);
   }
 
-  function updateUsername(username: string) {
-    updateAccount('username', username).then(logout);
+  function updateAndLogout(field: 'username' | 'email', value: string) {
+    updateAccount(field, value).then(logout);
   }
 
   useEffectAfterInitialLoad(() => {
@@ -44,11 +44,15 @@ function ProfileSettingsPage(): JSX.Element {
       <div className="flex flex-col gap-8">
         <AvatarSettings avatar={userData?.avatar?.toString() || ''} />
         <UsernameSettings
-          onSubmit={updateUsername}
+          onSubmit={(u) => updateAndLogout('username', u)}
           key={user.username + '1'}
           username={user.username}
         />
-        <EmailSettings key={user.email + '2'} email={user.email} />
+        <EmailSettings
+          onSubmit={(e) => updateAndLogout('email', e)}
+          key={user.email + '2'}
+          email={user.email}
+        />
         <ShipmentAddressSettings />
         <DeleteAccount />
       </div>

--- a/frontend/src/router/Router.tsx
+++ b/frontend/src/router/Router.tsx
@@ -13,6 +13,7 @@ import { loadCardDetails } from './loadCardDetails/loadCardDetails';
 import Search from '../pages/Search';
 import { loadSearchResults } from './loadSearchResults/loadSearchResults';
 import SellManagement from '../pages/yugioh/SellManagement';
+import { loadPublicUserInfo } from './loadPublicUserInfo/loadPublicUserInfo';
 
 const routes = createBrowserRouter([
   {
@@ -56,6 +57,7 @@ const routes = createBrowserRouter([
           {
             path: '',
             element: <ProfilePublicInfoPage />,
+            loader: loadPublicUserInfo,
           },
           {
             path: 'settings',

--- a/frontend/src/router/Router.tsx
+++ b/frontend/src/router/Router.tsx
@@ -60,6 +60,7 @@ const routes = createBrowserRouter([
           {
             path: 'settings',
             element: <ProfileSettingsPage />,
+            loader: authorizedGuard,
           },
           {
             path: 'blog',

--- a/frontend/src/router/loadPublicUserInfo/loadPublicUserInfo.spec.ts
+++ b/frontend/src/router/loadPublicUserInfo/loadPublicUserInfo.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { userService } from '../../services/user/user';
+import { loadPublicUserInfo } from './loadPublicUserInfo';
+
+describe('loadPublicUserInfo', () => {
+  it('Returns data successfully', async () => {
+    vi.spyOn(userService, 'getUserByUsername').mockResolvedValueOnce({
+      username: 'a',
+      avatar: 'b',
+    });
+
+    const result = await loadPublicUserInfo({
+      params: {
+        username: 'a',
+      },
+    });
+
+    expect(result.data.username).toBe('a');
+    expect(result.data.avatar).toBe('b');
+  });
+
+  it('Throws an error if the username is invalid', () => {
+    expect(() =>
+      loadPublicUserInfo({
+        params: {
+          username: '',
+        },
+      }),
+    ).rejects.toThrowError(Error);
+  });
+});

--- a/frontend/src/router/loadPublicUserInfo/loadPublicUserInfo.ts
+++ b/frontend/src/router/loadPublicUserInfo/loadPublicUserInfo.ts
@@ -1,0 +1,20 @@
+import { Params } from 'react-router-dom';
+import { userService } from '../../services/user/user';
+import { UserAccountLoader } from '../../services/user/types';
+
+/**
+ * A loader for the card details page.
+ * @throws an ``Error`` when the ``username`` route parameter is an empty string.
+ */
+export async function loadPublicUserInfo({
+  params,
+}: {
+  params: Params;
+}): Promise<UserAccountLoader> {
+  const username = params.username;
+  if (!username) {
+    throw new Error('invalid username');
+  }
+  const user = await userService.getUserByUsername(username);
+  return { data: user };
+}

--- a/frontend/src/services/http/http.ts
+++ b/frontend/src/services/http/http.ts
@@ -49,19 +49,25 @@ async function request<TResponseBody>(
   body?: any,
   params?: object,
 ): Promise<TResponseBody | undefined> {
-  const headers: HeadersInit = {
-    'Content-Type': 'application/json',
-  };
-
+  const headers: HeadersInit = {};
+  if (!(body instanceof FormData)) {
+    headers['Content-Type'] = 'application/json';
+  }
   const accessToken = localStorage.getItem('accessToken');
   if (accessToken) {
     headers.authorization = `Bearer ${accessToken}`;
   }
 
+  let requestBody;
+
+  if (body) {
+    requestBody = body instanceof FormData ? body : JSON.stringify(body);
+  }
+
   const request = {
     headers,
     method,
-    body: body ? JSON.stringify(body) : undefined,
+    body: requestBody,
   };
 
   if (params) {

--- a/frontend/src/services/user/types.ts
+++ b/frontend/src/services/user/types.ts
@@ -2,6 +2,12 @@ export type CurrentUser = {
   user_id: number;
   username: string;
   email: string;
+  shipping_address: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  phone_number: string | null;
+  city: string | null;
+  avatar: string | null;
 };
 
 export type AccessTokenResponse = {

--- a/frontend/src/services/user/types.ts
+++ b/frontend/src/services/user/types.ts
@@ -10,6 +10,12 @@ export type CurrentUser = {
   avatar: string | null;
 };
 
+export type JwtPayload = {
+  user_id: number;
+  username: string;
+  email: string;
+};
+
 export type AccessTokenResponse = {
   access: string;
 };

--- a/frontend/src/services/user/types.ts
+++ b/frontend/src/services/user/types.ts
@@ -23,3 +23,19 @@ export type UserLogin = {
   username: string;
   password: string;
 };
+
+export type UserAccount = {
+  username: string;
+  password: string;
+  email: string;
+  first_name: string | null;
+  last_name: string | null;
+  phone_number: string | null;
+  city: string | null;
+  shipping_address: string | null;
+  avatar: string | null;
+};
+
+export type UserAccountLoader = {
+  data: UserAccount;
+};

--- a/frontend/src/services/user/types.ts
+++ b/frontend/src/services/user/types.ts
@@ -51,3 +51,8 @@ export type UserAccount = {
 export type UserAccountLoader = {
   data: UserAccount;
 };
+
+export type PublicUserInfo = {
+  username: string;
+  avatar: string;
+};

--- a/frontend/src/services/user/types.ts
+++ b/frontend/src/services/user/types.ts
@@ -49,7 +49,7 @@ export type UserAccount = {
 };
 
 export type UserAccountLoader = {
-  data: UserAccount;
+  data: PublicUserInfo;
 };
 
 export type PublicUserInfo = {

--- a/frontend/src/services/user/user.ts
+++ b/frontend/src/services/user/user.ts
@@ -79,7 +79,7 @@ export const userService = {
     return user;
   },
 
-  async getUser(id: number): Promise<UserAccount> {
+  async getUserById(id: number): Promise<UserAccount> {
     const data = await httpService.get<UserAccount>(api.accounts.user(id));
     return data!;
   },

--- a/frontend/src/services/user/user.ts
+++ b/frontend/src/services/user/user.ts
@@ -83,4 +83,9 @@ export const userService = {
     const data = await httpService.get<UserAccount>(api.accounts.user(id));
     return data!;
   },
+
+  async updateUser(id: number, data: Partial<UserAccount>): Promise<UserAccount> {
+    const updatedData = await httpService.patch<UserAccount>(api.accounts.user(id), data);
+    return updatedData!;
+  },
 };

--- a/frontend/src/services/user/user.ts
+++ b/frontend/src/services/user/user.ts
@@ -2,12 +2,12 @@ import { jwtDecode } from 'jwt-decode';
 import { api } from '../../constants/api';
 import { httpService } from '../http/http';
 import {
-  CurrentUser,
   AccessTokenResponse,
   UserRegister,
   SuccessfulAuthenticationResponse,
   UserLogin,
   UserAccount,
+  JwtPayload,
 } from './types';
 
 export const userService = {
@@ -66,11 +66,11 @@ export const userService = {
    * @param jwt the token to be decoded
    * @returns data about the user that was extracted from the token
    */
-  extractUserFromToken(jwt: string): CurrentUser {
+  extractUserFromToken(jwt: string): JwtPayload {
     const decodedToken: any = jwtDecode(jwt);
 
     // transfer only business data, not JWT metadata.
-    const user: CurrentUser = {
+    const user: JwtPayload = {
       user_id: decodedToken.user_id,
       email: decodedToken.email,
       username: decodedToken.username,

--- a/frontend/src/services/user/user.ts
+++ b/frontend/src/services/user/user.ts
@@ -8,6 +8,7 @@ import {
   UserLogin,
   UserAccount,
   JwtPayload,
+  PublicUserInfo,
 } from './types';
 
 export const userService = {
@@ -81,6 +82,13 @@ export const userService = {
 
   async getUserById(id: number): Promise<UserAccount> {
     const data = await httpService.get<UserAccount>(api.accounts.userById(id));
+    return data!;
+  },
+
+  async getUserByUsername(username: string): Promise<PublicUserInfo> {
+    const data = await httpService.get<PublicUserInfo>(api.accounts.user, {
+      username,
+    });
     return data!;
   },
 

--- a/frontend/src/services/user/user.ts
+++ b/frontend/src/services/user/user.ts
@@ -7,6 +7,7 @@ import {
   UserRegister,
   SuccessfulAuthenticationResponse,
   UserLogin,
+  UserAccount,
 } from './types';
 
 export const userService = {
@@ -76,5 +77,10 @@ export const userService = {
     };
 
     return user;
+  },
+
+  async getUser(id: number): Promise<UserAccount> {
+    const data = await httpService.get<UserAccount>(api.accounts.user(id));
+    return data!;
   },
 };

--- a/frontend/src/services/user/user.ts
+++ b/frontend/src/services/user/user.ts
@@ -88,4 +88,8 @@ export const userService = {
     const updatedData = await httpService.patch<UserAccount>(api.accounts.user(id), data);
     return updatedData!;
   },
+
+  deleteUser(id: number): Promise<void> {
+    return httpService.del(api.accounts.user(id));
+  },
 };

--- a/frontend/src/services/user/user.ts
+++ b/frontend/src/services/user/user.ts
@@ -89,6 +89,13 @@ export const userService = {
     return updatedData!;
   },
 
+  async updateUserAvatar(id: number, avatar: File): Promise<UserAccount> {
+    const formData = new FormData();
+    formData.append('avatar', avatar, id.toString() + '.' + avatar.type.split('/')[1]);
+    const result = await httpService.patch<UserAccount>(api.accounts.user(id), formData);
+    return result!;
+  },
+
   deleteUser(id: number): Promise<void> {
     return httpService.del(api.accounts.user(id));
   },

--- a/frontend/src/services/user/user.ts
+++ b/frontend/src/services/user/user.ts
@@ -80,23 +80,23 @@ export const userService = {
   },
 
   async getUserById(id: number): Promise<UserAccount> {
-    const data = await httpService.get<UserAccount>(api.accounts.user(id));
+    const data = await httpService.get<UserAccount>(api.accounts.userById(id));
     return data!;
   },
 
   async updateUser(id: number, data: Partial<UserAccount>): Promise<UserAccount> {
-    const updatedData = await httpService.patch<UserAccount>(api.accounts.user(id), data);
+    const updatedData = await httpService.patch<UserAccount>(api.accounts.userById(id), data);
     return updatedData!;
   },
 
   async updateUserAvatar(id: number, avatar: File): Promise<UserAccount> {
     const formData = new FormData();
     formData.append('avatar', avatar, id.toString() + '.' + avatar.type.split('/')[1]);
-    const result = await httpService.patch<UserAccount>(api.accounts.user(id), formData);
+    const result = await httpService.patch<UserAccount>(api.accounts.userById(id), formData);
     return result!;
   },
 
   deleteUser(id: number): Promise<void> {
-    return httpService.del(api.accounts.user(id));
+    return httpService.del(api.accounts.userById(id));
   },
 };


### PR DESCRIPTION
This PR makes the profile settings page functional; all fields perform the necessary edits/deletions. A bunch of notes:
- when the user changes their username or email, they will be logged out. The reason for this is that their current tokens reflect their old username / email and I figured it'd be more appropriate to have them reauthenticate to receive tokens with up-to-date data. Corresponding texts in the fields have also been changed to reflect that. Let me know if this is not a desired behavior
- the httpService has been updated to handle multipart form data requests.
- the user context and session verification have been updated in this PR; when the user loads the app and has a valid session, the front end will make a request to retrieve the user data as well. This is because some of the newly implemented user data is needed in other parts of the app (for example, the avatar is needed in the navigation menu, the shipment address is needed in the upcoming shopping cart, etc.) and this prevents the need for the user data to be requested constantly.

EDIT:
- I updated the gitignore to include the directory with the avatars, let me know if this is not desired
- one of the type refactorings I did caused a build error in the Home page. This build error involved authentication logic that is already handled by ``App.tsx`` so I simply removed that part of the code. I mention this just so it's clear why I deleted it in this PR.