### PR TITLE
Adding card_in_set Field serializer to the listing

### DIFF
--- a/backend/listing/serializers.py
+++ b/backend/listing/serializers.py
@@ -1,3 +1,4 @@
+from yugioh.serializers import YugiohCardInSetSerializer
 from rest_framework import serializers
 from .models import Listing
 
@@ -5,11 +6,12 @@ from .models import Listing
 class ListingSerializer(serializers.ModelSerializer):
     card_name = serializers.CharField(read_only=True, source='card.yugioh_card')
     card_set_id = serializers.IntegerField(read_only=True, source='card.set.id')
+    card_in_set = YugiohCardInSetSerializer(read_only=True, source='card')
     user_name = serializers.CharField(read_only=True, source='user.username')
 
     class Meta:
         model = Listing
-        fields = ['id', 'card', 'card_name', 'card_set_id', 'user', 'user_name', 'price', 'condition', 'quantity',
+        fields = ['id', 'card', 'card_name', 'card_set_id', 'card_in_set','user', 'user_name', 'price', 'condition', 'quantity',
                   'is_listed', 'is_sold']
         read_only_fields = ['id', 'user']
         ordering_fields = ['id']


### PR DESCRIPTION
This PR adds detailed information for the card in set for the listing serializer as requested in  PR #50 

Now the listing response is updated as well as the GET shopping cart items endpoint response. 
Both now return everything needed as discussed for example:
 ```json
{
  "count": 1,
  "next": null,
  "previous": null,
  "results": [
    {
      "id": 9,
      "cart_name": "lichice",
      "listing": {
        "id": 1,
        "card": 2,
        "card_name": "Dark Magician",
        "card_set_id": 2,
        "card_in_set": {
          "id": 2,
          "yugioh_card": {   <-- the card
            "id": 1,
            "card_name": "Dark Magician",
            "type": "Normal Monster",
            "frame_type": "normal",
            "description": "''The ultimate wizard in terms of attack and defense.''",
            "attack": "2500",
            "defense": "2100",
            "level": "7",
            "race": "Spellcaster",
            "attribute": "DARK",
            "archetype": "Dark Magician",
            "image": "https://images.ygoprodeck.com/images/cards/46986421.jpg"
          },
          "set": {    <-- the set in which the card resides
            "id": 2,
            "card_set_name": "2016 Mega-Tins",
            "set_code": "CT13"
          },
          "rarity": {   <-- the rarity in which the card resides
            "id": 2,
            "rarity": "Ultra Rare",
            "rarity_code": "(UR)"
          }
        },
        "user": 1,
        "user_name": "admin",
        "price": 123,
        "condition": "mint",
        "quantity": 333,
        "is_listed": true,
        "is_sold": false
      },
      "quantity": 2,
      "total_price": 246
    }
  ]
} 
```