### PR TITLE
Fix issue #52

### DIFF
--- a/frontend/src/components/navigation/desktop/buttons/NotificationButton.tsx
+++ b/frontend/src/components/navigation/desktop/buttons/NotificationButton.tsx
@@ -8,6 +8,7 @@ function NotificationButton(): JSX.Element {
     <IconButton
       size="small"
       sx={{ borderWidth: 1, borderColor: secondaryTextColor, borderStyle: 'solid' }}
+      href="/sell/manage"
     >
       <NotificationsIcon />
     </IconButton>

--- a/frontend/src/components/navigation/mobile/menus/MobileLoggedInNav.tsx
+++ b/frontend/src/components/navigation/mobile/menus/MobileLoggedInNav.tsx
@@ -74,11 +74,11 @@ function MobileLoggedInNav(props: MobileLoggedInNavProps): JSX.Element {
         </List>
       </Collapse>
       <ListItem disablePadding>
-        <ListItemButton>
+        <ListItemButton href="/sell/manage">
           <ListItemIcon>
             <NotificationsIcon />
           </ListItemIcon>
-          <ListItemText primary="Notifications" />
+          <ListItemText primary="My listings" />
         </ListItemButton>
       </ListItem>
       <ListItem disablePadding>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -44,6 +44,7 @@ function Home(): JSX.Element {
             }}
             className="rounded-[7px]"
             startIcon={<Logo color="white" size={20} />}
+            href="/search"
           >
             Start exploring
           </Button>

--- a/frontend/src/pages/listing/EditListing.tsx
+++ b/frontend/src/pages/listing/EditListing.tsx
@@ -179,14 +179,13 @@ function EditListing(): JSX.Element {
   async function updateListing(e: React.FormEvent): Promise<void> {
     e.preventDefault();
     try {
-      const newData: YugiohCardSellListing = {
+      const newData: Partial<YugiohCardSellListing> = {
         quantity: Number(formData.quantity),
         condition: formData.condition,
         price: Number(formData.price),
-        is_sold: false,
         is_listed: formData.is_listed,
-        card: Number(params.id),
       };
+
       await yugiohService.updateCardListing(newData, id);
     } catch (error) {}
   }

--- a/frontend/src/services/yugioh/yugiohService.ts
+++ b/frontend/src/services/yugioh/yugiohService.ts
@@ -61,7 +61,10 @@ export const yugiohService = {
     return data!;
   },
 
-  async updateCardListing(listing: YugiohCardSellListing, id: number): Promise<YugiohCardListing> {
+  async updateCardListing(
+    listing: Partial<YugiohCardSellListing>,
+    id: number,
+  ): Promise<YugiohCardListing> {
     const data = await httpService.patch<YugiohCardListing>(api.yugioh.listing.id(id), listing);
     return data!;
   },


### PR DESCRIPTION
This PR addresses issue #52 and also makes the "Start exploring" button in the home page a hyperlink (which links to the search page). What used to be notification hyperlinks now lead to the sell pages. For the link in the mobile menu, the text has also been changed appropriately