### PR TITLE
Create a breadcrumb and fix current issues related to the old one

### DIFF
--- a/frontend/src/components/BreadcrumbNavigation.tsx
+++ b/frontend/src/components/BreadcrumbNavigation.tsx
@@ -17,6 +17,7 @@ type BreadcrumbNavigationProps = {
 };
 
 const fontSize = '1.875rem';
+const lineHeight = '2.25rem';
 
 /*
  *  Standard separator from MUI doesn't scale alongside
@@ -38,6 +39,7 @@ function BreadcrumbNavigation(props: BreadcrumbNavigationProps): JSX.Element {
           color="inherit"
           href={l.href}
           className="flex justify-self-start"
+          lineHeight={lineHeight}
         >
           {l.text}
         </Link>
@@ -48,6 +50,7 @@ function BreadcrumbNavigation(props: BreadcrumbNavigationProps): JSX.Element {
         className="m-0 p-0 inline align-middle"
         fontSize={fontSize}
         color="text.primary"
+        lineHeight={lineHeight}
       >
         {props.heading}
       </Typography>

--- a/frontend/src/components/BreadcrumbNavigation.tsx
+++ b/frontend/src/components/BreadcrumbNavigation.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PageHeader from './PageHeader';
+import { Breadcrumbs, Link, Typography } from '@mui/material';
+
+export type BreadcrumbLink = {
+  text: string;
+  /**
+   * href should be relative (e.g. ``/sell``);
+   */
+  href: string;
+};
+
+type BreadcrumbNavigationProps = {
+  links: BreadcrumbLink[];
+  heading: React.ReactNode;
+  children?: React.ReactNode | null;
+};
+
+const fontSize = '1.875rem';
+
+/*
+ *  Standard separator from MUI doesn't scale alongside
+ *  the links/text's size, so using this
+ *  as a custom separator.
+ */
+function Separator(): JSX.Element {
+  return <span className="text-3xl">/</span>;
+}
+
+function BreadcrumbNavigation(props: BreadcrumbNavigationProps): JSX.Element {
+  const BreadcrumbLinks = (
+    <Breadcrumbs className="breadcrumb-navigation" separator={<Separator />}>
+      {props.links.map((l) => (
+        <Link
+          fontSize={fontSize}
+          key={l.text + l.href}
+          underline="hover"
+          color="inherit"
+          href={l.href}
+          className="flex justify-self-start"
+        >
+          {l.text}
+        </Link>
+      ))}
+
+      <Typography
+        component="h1"
+        className="m-0 p-0 inline align-middle"
+        fontSize={fontSize}
+        color="text.primary"
+      >
+        {props.heading}
+      </Typography>
+    </Breadcrumbs>
+  );
+
+  return <PageHeader heading={BreadcrumbLinks}>{props.children}</PageHeader>;
+}
+
+export default BreadcrumbNavigation;

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -10,7 +10,7 @@ type PageHeaderProps = {
    */
   children?: React.ReactNode | null;
 
-  heading: string;
+  heading: React.ReactNode;
 };
 
 /**
@@ -23,11 +23,18 @@ type PageHeaderProps = {
 function PageHeader(props: PageHeaderProps): JSX.Element {
   const className = props.className || '';
 
+  const heading =
+    typeof props.heading === 'string' ? (
+      <h1 className="text-3xl font-bold">{props.heading}</h1>
+    ) : (
+      props.heading
+    );
+
   return (
     <header
       className={`lg:pl-24 gap-4 lg:gap-0 flex flex-col items-center justify-center lg:justify-between lg:flex-row pb-8 pt-8 border-b-2 border-stone-300 text-center lg:text-left bg-white ${className}`}
     >
-      <h1 className="text-3xl font-bold">{props.heading}</h1>
+      {heading}
       <div className="lg:pr-8">{props.children}</div>
     </header>
   );

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -25,7 +25,7 @@ function PageHeader(props: PageHeaderProps): JSX.Element {
 
   const heading =
     typeof props.heading === 'string' ? (
-      <h1 className="text-3xl font-bold">{props.heading}</h1>
+      <h1 className="text-3xl">{props.heading}</h1>
     ) : (
       props.heading
     );

--- a/frontend/src/components/sellListing/NewListingTopBar.tsx
+++ b/frontend/src/components/sellListing/NewListingTopBar.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { condition } from '../../services/yugioh/types';
-import PageHeader from '../PageHeader';
+import BreadcrumbNavigation, { BreadcrumbLink } from '../BreadcrumbNavigation';
 
 type NewListingTopBarProps = {
   handleSubmit: (e: React.FormEvent, postAnother: boolean) => Promise<void>;
@@ -43,8 +43,15 @@ const NewListingTopBar: React.FC<NewListingTopBarProps> = ({
     }
   };
 
+  const breadcrumbNavigation: BreadcrumbLink[] = [
+    {
+      href: '/sell/manage',
+      text: 'Sell',
+    },
+  ];
+
   return (
-    <PageHeader heading="Sell / New Listing">
+    <BreadcrumbNavigation links={breadcrumbNavigation} heading="New Listing">
       {/* TO-DO: update URL */}
       <div className="flex items-center">
         <input
@@ -71,7 +78,7 @@ const NewListingTopBar: React.FC<NewListingTopBarProps> = ({
           Post
         </button>
       </div>
-    </PageHeader>
+    </BreadcrumbNavigation>
   );
 };
 

--- a/frontend/src/pages/Cart.tsx
+++ b/frontend/src/pages/Cart.tsx
@@ -1,4 +1,3 @@
-import PageHeader from '../components/PageHeader';
 import { useCurrentUser } from '../context/user';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -12,6 +11,7 @@ import { useEffectAfterInitialLoad } from '../util/useEffectAfterInitialLoad';
 import { errorToast } from '../util/errorToast';
 import toast from 'react-hot-toast';
 import { toastMessages } from '../constants/toast';
+import BreadcrumbNavigation, { BreadcrumbLink } from '../components/BreadcrumbNavigation';
 
 function ShoppingCart(): JSX.Element {
   const { user } = useCurrentUser();
@@ -92,9 +92,16 @@ function ShoppingCart(): JSX.Element {
     shoppingCartService.getItems(undefined, page).then(loadShoppingCart).catch(errorToast);
   }, [page]);
 
+  const breadcrumbNavigation: BreadcrumbLink[] = [
+    {
+      href: '/search',
+      text: 'Buy',
+    },
+  ];
+
   return (
     <>
-      <PageHeader heading="Shopping cart" />
+      <BreadcrumbNavigation links={breadcrumbNavigation} heading="Checkout" />
       <div
         id="summary"
         className="flex flex-col items-center lg:flex-row lg:items-start pb-4 pt-4 justify-center gap-4 bg-[#F5F5F5]"

--- a/frontend/src/pages/Cart.tsx
+++ b/frontend/src/pages/Cart.tsx
@@ -94,7 +94,7 @@ function ShoppingCart(): JSX.Element {
 
   const breadcrumbNavigation: BreadcrumbLink[] = [
     {
-      href: '/search',
+      href: '/buy',
       text: 'Buy',
     },
   ];

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -1,6 +1,5 @@
 import { useLoaderData, useNavigate, useParams } from 'react-router-dom';
 import { CardSearchLoader } from '../services/yugioh/types';
-import PageHeader from '../components/PageHeader';
 import MarketTable from '../components/marketTable/MarketTable';
 import React, { useState } from 'react';
 import SearchTableRow from '../components/search/SearchTableRow';
@@ -10,6 +9,7 @@ import { yugiohService } from '../services/yugioh/yugiohService';
 import { useEffectAfterInitialLoad } from '../util/useEffectAfterInitialLoad';
 import ListingTopBar from '../components/sellListing/ListingTopBar';
 import { errorToast } from '../util/errorToast';
+import BreadcrumbNavigation, { BreadcrumbLink } from '../components/BreadcrumbNavigation';
 
 function Search(): JSX.Element {
   const data: CardSearchLoader = useLoaderData() as CardSearchLoader;
@@ -19,6 +19,13 @@ function Search(): JSX.Element {
   const [page, setPage] = useState(1);
   const pages = Math.ceil(cards.count / 10);
   const [searchQuery, setSearchQuery] = useState(params.query || '');
+
+  const breadcrumbNavigation: BreadcrumbLink[] = [
+    {
+      href: '/search',
+      text: 'Buy',
+    },
+  ];
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     event.preventDefault();
@@ -72,7 +79,7 @@ function Search(): JSX.Element {
   return (
     <section className="bg-[#F5F5F5] min-h-[100vh]">
       <ListingTopBar />
-      <PageHeader heading="Buy / Search" />
+      <BreadcrumbNavigation heading="Search" links={breadcrumbNavigation} />
       <div className="min-h-full mt-2 flex items-center w-full flex-col gap-4">
         <form className="w-2/3 bg-white relative z-0" onSubmit={handleSubmit}>
           <TextField

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -22,7 +22,7 @@ function Search(): JSX.Element {
 
   const breadcrumbNavigation: BreadcrumbLink[] = [
     {
-      href: '/search',
+      href: '/buy',
       text: 'Buy',
     },
   ];

--- a/frontend/src/pages/yugioh/YugiohCardDetails.tsx
+++ b/frontend/src/pages/yugioh/YugiohCardDetails.tsx
@@ -40,7 +40,7 @@ function YugiohCardDetails(): JSX.Element {
   const breadcrumbNavigation: BreadcrumbLink[] = [
     {
       text: 'Buy',
-      href: '/search',
+      href: '/buy',
     },
     {
       text: 'Search',

--- a/frontend/src/pages/yugioh/YugiohCardDetails.tsx
+++ b/frontend/src/pages/yugioh/YugiohCardDetails.tsx
@@ -1,5 +1,4 @@
 import { useLoaderData, useParams } from 'react-router-dom';
-import PageHeader from '../../components/PageHeader';
 import YugiohCardImage from '../../components/yugioh/YugiohCardImage';
 import YugiohCardDetailsTable from '../../components/yugioh/table/YugiohCardDetailsTable';
 import YugiohCardMarket from '../../components/yugioh/table/market/YugiohCardMarket';
@@ -9,6 +8,7 @@ import { Pagination } from '@mui/material';
 import { yugiohService } from '../../services/yugioh/yugiohService';
 import { useEffectAfterInitialLoad } from '../../util/useEffectAfterInitialLoad';
 import { errorToast } from '../../util/errorToast';
+import BreadcrumbNavigation, { BreadcrumbLink } from '../../components/BreadcrumbNavigation';
 
 function YugiohCardDetails(): JSX.Element {
   const data = useLoaderData() as CardDetailsLoaderData;
@@ -37,9 +37,23 @@ function YugiohCardDetails(): JSX.Element {
     setPage(1);
   }, [params.id]);
 
+  const breadcrumbNavigation: BreadcrumbLink[] = [
+    {
+      text: 'Buy',
+      href: '/search',
+    },
+    {
+      text: 'Search',
+      href: '/search',
+    },
+  ];
+
   return (
     <section className="bg-[#F5F5F5]">
-      <PageHeader heading={`Buy / Search / ${cardInSet.yugioh_card.card_name}`}></PageHeader>
+      <BreadcrumbNavigation
+        links={breadcrumbNavigation}
+        heading={cardInSet.yugioh_card.card_name}
+      />
       <div className="flex flex-col pt-4 pb-4 lg:flex-row justify-center items-center lg:items-start gap-8">
         <YugiohCardImage src={cardInSet.yugioh_card.image} />
         <YugiohCardDetailsTable cardInSet={cardInSet} />


### PR DESCRIPTION
This PR tackles #67 by creating a reusable breadcrumb (which utilizes the one provided by MUI). The component accepts an array of data for each link to make it more flexible and the type for the link data object is also exported so that consumers can define their breadcrumb navigation without cluttering the JSX area of the component significantly.

The breadcrumb also applies colors correctly, with the links having a gray color and the last item (the heading) having a black color.

This PR also introduces a slight change to the ``PageHeader`` component. To be more specific, if ``heading`` is a non-string ReactNode, the component will directly render that instead of rendering it in an ``h1``. The behavior remains unchanged if the heading is a string.

Disclaimer: currently, the "Buy" link items redirect to the search page, as I am not sure where it's supposed to actually lead to. There is also one page (the card details page) where there's another breadcrumb link (/ Search /) that leads to the same page. If it's supposed to link to somewhere else, let me know, as this is an easy fix. Let me know as well if I missed an area where I didn't apply the breadcrumb