### PR TITLE
Implement user dropdown for profile picture avatar and update mobile menu

### DIFF
--- a/frontend/src/components/navigation/desktop/DesktopLoggedInNav.tsx
+++ b/frontend/src/components/navigation/desktop/DesktopLoggedInNav.tsx
@@ -22,11 +22,6 @@ function DesktopLoggedInNav(): JSX.Element {
       <li>
         <ProfilePictureAvatar imageUrl={user.avatar} />
       </li>
-      {/* <li>
-        <Button onClick={handleLogout} color="primary" variant="outlined">
-          Sign Out
-        </Button>
-      </li> */}
     </ul>
   );
 }

--- a/frontend/src/components/navigation/desktop/DesktopLoggedInNav.tsx
+++ b/frontend/src/components/navigation/desktop/DesktopLoggedInNav.tsx
@@ -1,11 +1,7 @@
-import { Button } from '@mui/material';
 import ProfilePictureAvatar from '../profilePictureAvatar/ProfilePictureAvatar';
 import NewActionButton from './buttons/NewActionButton';
 import NotificationButton from './buttons/NotificationButton';
-import { useLogout } from '../../../util/useLogout';
 import { useCurrentUser } from '../../../context/user';
-import toast from 'react-hot-toast';
-import { toastMessages } from '../../../constants/toast';
 
 /**
  * A list of navigation items for logged in users.
@@ -13,13 +9,7 @@ import { toastMessages } from '../../../constants/toast';
  * @returns
  */
 function DesktopLoggedInNav(): JSX.Element {
-  const logout = useLogout();
   const { user } = useCurrentUser();
-
-  function handleLogout() {
-    logout();
-    toast.success(toastMessages.success.logout);
-  }
 
   return (
     <ul className="list-none flex gap-4 items-center">
@@ -32,11 +22,11 @@ function DesktopLoggedInNav(): JSX.Element {
       <li>
         <ProfilePictureAvatar imageUrl={user.avatar} />
       </li>
-      <li>
+      {/* <li>
         <Button onClick={handleLogout} color="primary" variant="outlined">
           Sign Out
         </Button>
-      </li>
+      </li> */}
     </ul>
   );
 }

--- a/frontend/src/components/navigation/mobile/menus/MobileLoggedInNav.tsx
+++ b/frontend/src/components/navigation/mobile/menus/MobileLoggedInNav.tsx
@@ -110,13 +110,13 @@ function MobileLoggedInNav(props: MobileLoggedInNavProps): JSX.Element {
             <ListItemIcon>
               <AddShoppingCartIcon />
             </ListItemIcon>
-            <ListItemText>My orders</ListItemText>
+            <ListItemText primary="My orders" />
           </ListItemButton>
           <ListItemButton sx={{ pl: 4 }} href="/sales">
             <ListItemIcon>
               <CurrencyExchangeIcon />
             </ListItemIcon>
-            <ListItemText>My sales</ListItemText>
+            <ListItemText primary="My sales" />
           </ListItemButton>
           <ListItemButton sx={{ pl: 4 }} onClick={handleLogout}>
             <ListItemIcon>

--- a/frontend/src/components/navigation/mobile/menus/MobileLoggedInNav.tsx
+++ b/frontend/src/components/navigation/mobile/menus/MobileLoggedInNav.tsx
@@ -7,6 +7,7 @@ import {
   ListItemButton,
   ListItemIcon,
   ListItemText,
+  SvgIconTypeMap,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import ExpandLess from '@mui/icons-material/ExpandLess';
@@ -21,10 +22,19 @@ import { toastMessages } from '../../../../constants/toast';
 import SettingsIcon from '@mui/icons-material/Settings';
 import AddShoppingCartIcon from '@mui/icons-material/AddShoppingCart';
 import CurrencyExchangeIcon from '@mui/icons-material/CurrencyExchange';
+import { OverridableComponent } from '@mui/material/OverridableComponent';
 
 type NewActionLink = {
   url: string;
   label: string;
+};
+
+type ProfileLink = {
+  href: string;
+  icon: OverridableComponent<SvgIconTypeMap<object, 'svg'>> & {
+    muiName: string;
+  };
+  text: string;
 };
 
 type MobileLoggedInNavProps = {
@@ -40,6 +50,24 @@ function MobileLoggedInNav(props: MobileLoggedInNavProps): JSX.Element {
   const [profileExpanded, setProfileExpanded] = useState(false);
   const { user } = useCurrentUser();
   const logout = useLogout();
+
+  const links: ProfileLink[] = [
+    {
+      href: `/user/${user.username}/settings`,
+      text: 'Account settings',
+      icon: SettingsIcon,
+    },
+    {
+      href: '/orders',
+      text: 'My orders',
+      icon: AddShoppingCartIcon,
+    },
+    {
+      href: '/sales',
+      text: 'My sales',
+      icon: CurrencyExchangeIcon,
+    },
+  ];
 
   function handleLogout() {
     logout();
@@ -100,24 +128,17 @@ function MobileLoggedInNav(props: MobileLoggedInNavProps): JSX.Element {
       </ListItem>
       <Collapse in={profileExpanded} timeout="auto" unmountOnExit>
         <List disablePadding>
-          <ListItemButton sx={{ pl: 4 }} href={`/user/${user.username}/settings`}>
-            <ListItemIcon>
-              <SettingsIcon />
-            </ListItemIcon>
-            <ListItemText primary="Account settings" />
-          </ListItemButton>
-          <ListItemButton sx={{ pl: 4 }} href="/orders">
-            <ListItemIcon>
-              <AddShoppingCartIcon />
-            </ListItemIcon>
-            <ListItemText primary="My orders" />
-          </ListItemButton>
-          <ListItemButton sx={{ pl: 4 }} href="/sales">
-            <ListItemIcon>
-              <CurrencyExchangeIcon />
-            </ListItemIcon>
-            <ListItemText primary="My sales" />
-          </ListItemButton>
+          {links.map((l) => {
+            const LinkIcon = l.icon;
+            return (
+              <ListItemButton sx={{ pl: 4 }} href={l.href}>
+                <ListItemIcon>
+                  <LinkIcon />
+                </ListItemIcon>
+                <ListItemText primary={l.text} />
+              </ListItemButton>
+            );
+          })}
           <ListItemButton sx={{ pl: 4 }} onClick={handleLogout}>
             <ListItemIcon>
               <LogoutIcon />

--- a/frontend/src/components/navigation/mobile/menus/MobileLoggedInNav.tsx
+++ b/frontend/src/components/navigation/mobile/menus/MobileLoggedInNav.tsx
@@ -18,6 +18,9 @@ import { useCurrentUser } from '../../../../context/user';
 import { useLogout } from '../../../../util/useLogout';
 import toast from 'react-hot-toast';
 import { toastMessages } from '../../../../constants/toast';
+import SettingsIcon from '@mui/icons-material/Settings';
+import AddShoppingCartIcon from '@mui/icons-material/AddShoppingCart';
+import CurrencyExchangeIcon from '@mui/icons-material/CurrencyExchange';
 
 type NewActionLink = {
   url: string;
@@ -33,9 +36,11 @@ type MobileLoggedInNavProps = {
  * @returns
  */
 function MobileLoggedInNav(props: MobileLoggedInNavProps): JSX.Element {
-  const [expanded, setExpanded] = useState(false);
+  const [newActionsExpanded, setNewActionsExpanded] = useState(false);
+  const [profileExpanded, setProfileExpanded] = useState(false);
   const { user } = useCurrentUser();
   const logout = useLogout();
+
   function handleLogout() {
     logout();
     props.onClose();
@@ -56,15 +61,15 @@ function MobileLoggedInNav(props: MobileLoggedInNavProps): JSX.Element {
   return (
     <>
       <ListItem disablePadding>
-        <ListItemButton onClick={() => setExpanded((e) => !e)}>
+        <ListItemButton onClick={() => setNewActionsExpanded((e) => !e)}>
           <ListItemIcon>
             <AddIcon />
           </ListItemIcon>
           <ListItemText primary="New action" />
-          {expanded ? <ExpandLess /> : <ExpandMore />}
+          {newActionsExpanded ? <ExpandLess /> : <ExpandMore />}
         </ListItemButton>
       </ListItem>
-      <Collapse in={expanded} timeout="auto" unmountOnExit>
+      <Collapse in={newActionsExpanded} timeout="auto" unmountOnExit>
         <List disablePadding>
           {actions.map((a) => (
             <ListItemButton key={a.label} sx={{ pl: 4 }} href={a.url}>
@@ -85,19 +90,42 @@ function MobileLoggedInNav(props: MobileLoggedInNavProps): JSX.Element {
         </ListItemButton>
       </ListItem>
       <ListItem disablePadding>
-        <ListItemButton href={`/user/${user.username}/settings`}>
+        <ListItemButton onClick={() => setProfileExpanded((e) => !e)}>
           <ListItemAvatar>
             <Avatar sx={{ width: 24, height: 24 }} src={user.avatar || ''} />
           </ListItemAvatar>
           <ListItemText primary="My profile" />
+          {profileExpanded ? <ExpandLess /> : <ExpandMore />}
         </ListItemButton>
       </ListItem>
-      <ListItemButton onClick={handleLogout}>
-        <ListItemIcon>
-          <LogoutIcon />
-        </ListItemIcon>
-        <ListItemText primary="Sign Out" />
-      </ListItemButton>
+      <Collapse in={profileExpanded} timeout="auto" unmountOnExit>
+        <List disablePadding>
+          <ListItemButton sx={{ pl: 4 }} href={`/user/${user.username}/settings`}>
+            <ListItemIcon>
+              <SettingsIcon />
+            </ListItemIcon>
+            <ListItemText primary="Account settings" />
+          </ListItemButton>
+          <ListItemButton sx={{ pl: 4 }} href="/orders">
+            <ListItemIcon>
+              <AddShoppingCartIcon />
+            </ListItemIcon>
+            <ListItemText>My orders</ListItemText>
+          </ListItemButton>
+          <ListItemButton sx={{ pl: 4 }} href="/sales">
+            <ListItemIcon>
+              <CurrencyExchangeIcon />
+            </ListItemIcon>
+            <ListItemText>My sales</ListItemText>
+          </ListItemButton>
+          <ListItemButton sx={{ pl: 4 }} onClick={handleLogout}>
+            <ListItemIcon>
+              <LogoutIcon />
+            </ListItemIcon>
+            <ListItemText primary="Sign Out" />
+          </ListItemButton>
+        </List>
+      </Collapse>
     </>
   );
 }

--- a/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.css
+++ b/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.css
@@ -1,0 +1,7 @@
+.profile-picture-avatar-menu .MuiPaper-root {
+  border: 1px solid #666666;
+}
+
+.profile-picture-avatar-menu a:hover, .profile-picture-avatar-menu .logout-button:hover {
+  background-color: rgba(21, 181, 141, 0.2);
+}

--- a/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.css
+++ b/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.css
@@ -5,3 +5,8 @@
 .profile-picture-avatar-menu a:hover, .profile-picture-avatar-menu .logout-button:hover {
   background-color: rgba(21, 181, 141, 0.2);
 }
+
+.profile-picture-avatar-menu hr {
+  margin: 0 auto;
+  width: 85%;
+}

--- a/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.tsx
+++ b/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.tsx
@@ -64,7 +64,7 @@ function ProfilePictureAvatar(props: ProfilePictureAvatarProps): JSX.Element {
         <ListItem sx={{ paddingTop: 2, paddingBottom: 2 }}>
           <Typography color="text.secondary">{user.email}</Typography>
         </ListItem>
-        <Divider className="w-4/5" sx={{ margin: '0 auto' }} />
+        <Divider />
         <ListItemButton
           onClick={handleClose}
           sx={{ padding }}
@@ -93,7 +93,7 @@ function ProfilePictureAvatar(props: ProfilePictureAvatarProps): JSX.Element {
             <CurrencyExchangeIcon fontSize="small" />
           </ListItemIcon>
         </ListItemButton>
-        <Divider className="w-4/5" sx={{ margin: '0 auto' }} />
+        <Divider />
         <ListItemButton
           className="logout-button"
           onClick={handleLogout}

--- a/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.tsx
+++ b/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.tsx
@@ -86,34 +86,6 @@ function ProfilePictureAvatar(props: ProfilePictureAvatarProps): JSX.Element {
           <Typography color="text.secondary">{user.email}</Typography>
         </ListItem>
         <Divider />
-        {/* <ListItemButton
-          onClick={handleClose}
-          sx={{ padding }}
-          href={`/user/${user.username}/settings`}
-        >
-          <ListItemText>
-            <Typography color="text.secondary">Account settings</Typography>
-          </ListItemText>
-          <ListItemIcon className="justify-end">
-            <SettingsIcon fontSize="small" />
-          </ListItemIcon>
-        </ListItemButton>
-        <ListItemButton onClick={handleClose} sx={{ padding }} href="/orders">
-          <ListItemText>
-            <Typography color="text.secondary">My orders</Typography>
-          </ListItemText>
-          <ListItemIcon className="justify-end">
-            <AddShoppingCartIcon fontSize="small" />
-          </ListItemIcon>
-        </ListItemButton>
-        <ListItemButton onClick={handleClose} sx={{ padding }} href="/sales">
-          <ListItemText>
-            <Typography color="text.secondary">My sales</Typography>
-          </ListItemText>
-          <ListItemIcon className="justify-end">
-            <CurrencyExchangeIcon fontSize="small" />
-          </ListItemIcon>
-        </ListItemButton> */}
         {links.map((l) => {
           const LinkIcon = l.icon;
           return (

--- a/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.tsx
+++ b/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.tsx
@@ -7,10 +7,11 @@ import {
   ListItemIcon,
   ListItemText,
   Menu,
+  SvgIconTypeMap,
   Typography,
 } from '@mui/material';
 import { useCurrentUser } from '../../../context/user';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import SettingsIcon from '@mui/icons-material/Settings';
 import AddShoppingCartIcon from '@mui/icons-material/AddShoppingCart';
 import CurrencyExchangeIcon from '@mui/icons-material/CurrencyExchange';
@@ -18,6 +19,7 @@ import { useLogout } from '../../../util/useLogout';
 import toast from 'react-hot-toast';
 import { toastMessages } from '../../../constants/toast';
 import './ProfilePictureAvatar.css';
+import { OverridableComponent } from '@mui/material/OverridableComponent';
 
 type ProfilePictureAvatarProps = {
   imageUrl: string | null;
@@ -36,6 +38,24 @@ function ProfilePictureAvatar(props: ProfilePictureAvatarProps): JSX.Element {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const menuIsOpen = anchorEl !== null;
   const logout = useLogout();
+
+  const links: ProfileLink[] = [
+    {
+      href: `/user/${user.username}/settings`,
+      text: 'Account settings',
+      icon: SettingsIcon,
+    },
+    {
+      href: '/orders',
+      text: 'My orders',
+      icon: AddShoppingCartIcon,
+    },
+    {
+      href: '/sales',
+      text: 'My sales',
+      icon: CurrencyExchangeIcon,
+    },
+  ];
 
   function handleLogout() {
     logout();
@@ -66,7 +86,7 @@ function ProfilePictureAvatar(props: ProfilePictureAvatarProps): JSX.Element {
           <Typography color="text.secondary">{user.email}</Typography>
         </ListItem>
         <Divider />
-        <ListItemButton
+        {/* <ListItemButton
           onClick={handleClose}
           sx={{ padding }}
           href={`/user/${user.username}/settings`}
@@ -93,7 +113,20 @@ function ProfilePictureAvatar(props: ProfilePictureAvatarProps): JSX.Element {
           <ListItemIcon className="justify-end">
             <CurrencyExchangeIcon fontSize="small" />
           </ListItemIcon>
-        </ListItemButton>
+        </ListItemButton> */}
+        {links.map((l) => {
+          const LinkIcon = l.icon;
+          return (
+            <ListItemButton onClick={handleClose} sx={{ padding }} href={l.href}>
+              <ListItemText>
+                <Typography color="text.secondary">{l.text}</Typography>
+              </ListItemText>
+              <ListItemIcon className="justify-end">
+                <LinkIcon fontSize="small" />
+              </ListItemIcon>
+            </ListItemButton>
+          );
+        })}
         <Divider />
         <ListItemButton
           className="logout-button"
@@ -106,5 +139,13 @@ function ProfilePictureAvatar(props: ProfilePictureAvatarProps): JSX.Element {
     </>
   );
 }
+
+type ProfileLink = {
+  href: string;
+  icon: OverridableComponent<SvgIconTypeMap<object, 'svg'>> & {
+    muiName: string;
+  };
+  text: string;
+};
 
 export default ProfilePictureAvatar;

--- a/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.tsx
+++ b/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.tsx
@@ -26,7 +26,8 @@ type ProfilePictureAvatarProps = {
 const padding = '8px 16px';
 
 /**
- * An avatar image which links to the user's profile
+ * An avatar image which opens a dropdown with various links
+ * to personalized pages
  * @param props
  * @returns
  */

--- a/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.tsx
+++ b/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.tsx
@@ -64,7 +64,7 @@ function ProfilePictureAvatar(props: ProfilePictureAvatarProps): JSX.Element {
         <ListItem sx={{ paddingTop: 2, paddingBottom: 2 }}>
           <Typography color="text.secondary">{user.email}</Typography>
         </ListItem>
-        <Divider />
+        <Divider className="w-4/5" sx={{ margin: '0 auto' }} />
         <ListItemButton
           onClick={handleClose}
           sx={{ padding }}
@@ -93,7 +93,7 @@ function ProfilePictureAvatar(props: ProfilePictureAvatarProps): JSX.Element {
             <CurrencyExchangeIcon fontSize="small" />
           </ListItemIcon>
         </ListItemButton>
-        <Divider />
+        <Divider className="w-4/5" sx={{ margin: '0 auto' }} />
         <ListItemButton
           className="logout-button"
           onClick={handleLogout}

--- a/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.tsx
+++ b/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.tsx
@@ -1,22 +1,108 @@
-import { Avatar, Link } from '@mui/material';
+import {
+  Avatar,
+  Divider,
+  IconButton,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  Typography,
+} from '@mui/material';
 import { useCurrentUser } from '../../../context/user';
+import { useState } from 'react';
+import SettingsIcon from '@mui/icons-material/Settings';
+import AddShoppingCartIcon from '@mui/icons-material/AddShoppingCart';
+import CurrencyExchangeIcon from '@mui/icons-material/CurrencyExchange';
+import { useLogout } from '../../../util/useLogout';
+import toast from 'react-hot-toast';
+import { toastMessages } from '../../../constants/toast';
+import './ProfilePictureAvatar.css';
 
-type ProfilePictureAvatar = {
+type ProfilePictureAvatarProps = {
   imageUrl: string | null;
 };
+
+const padding = '8px 16px';
 
 /**
  * An avatar image which links to the user's profile
  * @param props
  * @returns
  */
-function ProfilePictureAvatar(props: ProfilePictureAvatar): JSX.Element {
+function ProfilePictureAvatar(props: ProfilePictureAvatarProps): JSX.Element {
   const { user } = useCurrentUser();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const menuIsOpen = anchorEl !== null;
+  const logout = useLogout();
 
+  function handleLogout() {
+    logout();
+    handleClose();
+    toast.success(toastMessages.success.logout);
+  }
+
+  function handleClick(event: React.MouseEvent<HTMLButtonElement>) {
+    setAnchorEl(event.currentTarget);
+  }
+
+  function handleClose() {
+    setAnchorEl(null);
+  }
   return (
-    <Link href={`/user/${user.username}/settings`}>
-      <Avatar src={props.imageUrl || ''} />
-    </Link>
+    <>
+      <IconButton onClick={handleClick}>
+        <Avatar src={props.imageUrl || ''} />
+      </IconButton>
+      <Menu
+        className="profile-picture-avatar-menu"
+        color="text.secondary"
+        anchorEl={anchorEl}
+        open={menuIsOpen}
+        onClose={handleClose}
+      >
+        <ListItem sx={{ paddingTop: 2, paddingBottom: 2 }}>
+          <Typography color="text.secondary">{user.email}</Typography>
+        </ListItem>
+        <Divider />
+        <ListItemButton
+          onClick={handleClose}
+          sx={{ padding }}
+          href={`/user/${user.username}/settings`}
+        >
+          <ListItemText>
+            <Typography color="text.secondary">Account settings</Typography>
+          </ListItemText>
+          <ListItemIcon className="justify-end">
+            <SettingsIcon fontSize="small" />
+          </ListItemIcon>
+        </ListItemButton>
+        <ListItemButton onClick={handleClose} sx={{ padding }} href="/orders">
+          <ListItemText>
+            <Typography color="text.secondary">My orders</Typography>
+          </ListItemText>
+          <ListItemIcon className="justify-end">
+            <AddShoppingCartIcon fontSize="small" />
+          </ListItemIcon>
+        </ListItemButton>
+        <ListItemButton onClick={handleClose} sx={{ padding }} href="/sales">
+          <ListItemText>
+            <Typography color="text.secondary">My sales</Typography>
+          </ListItemText>
+          <ListItemIcon className="justify-end">
+            <CurrencyExchangeIcon fontSize="small" />
+          </ListItemIcon>
+        </ListItemButton>
+        <Divider />
+        <ListItemButton
+          className="logout-button"
+          onClick={handleLogout}
+          sx={{ paddingTop: 2, paddingBottom: 2 }}
+        >
+          <Typography color="text.secondary">Log out</Typography>
+        </ListItemButton>
+      </Menu>
+    </>
   );
 }
 


### PR DESCRIPTION
This PR addresses #68. Some of the links obviously do not work (and can also be updated if we decide to change them).

Because the dropdown features a logout button, the previous one has been removed from the desktop variant

The mobile menu has also been updated; what used to be the "My profile" link is now a collapsible button that reveals all four links / actions (this includes the logout button which has been moved from its previous location) that can be accessed on the desktop variant. The only relevant difference between the mobile and desktop variants is that the mobile one doesn't feature the email, as I am not sure how I feel about featuring non-clickable elements in it (unless the email part is also supposed to be a hyperlink?).

There are a few minor changes I have gone with that deviate from the wireframes:
- I have increased the padding of the middle links in the desktop variant to make them easier to click
- I also added a divider after the email for better separation

let me know if there's anything to fix / change / revert / etc.