### PR TITLE
Create changelog page

### DIFF
--- a/frontend/src/components/about/ChangelogBullet.tsx
+++ b/frontend/src/components/about/ChangelogBullet.tsx
@@ -4,7 +4,7 @@ import ErrorIcon from '@mui/icons-material/Error';
 import { SvgIconTypeMap } from '@mui/material';
 import { OverridableComponent } from '@mui/material/OverridableComponent';
 
-type changelogBullet = 'feature' | 'fix' | 'deprecation';
+export type changelogBullet = 'feature' | 'fix' | 'deprecation';
 
 type ChangelogIcon = {
   BulletIcon: OverridableComponent<SvgIconTypeMap<object, 'svg'>> & {

--- a/frontend/src/components/about/ChangelogBullet.tsx
+++ b/frontend/src/components/about/ChangelogBullet.tsx
@@ -1,0 +1,41 @@
+import AddCircleIcon from '@mui/icons-material/AddCircle';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ErrorIcon from '@mui/icons-material/Error';
+import { SvgIconTypeMap } from '@mui/material';
+import { OverridableComponent } from '@mui/material/OverridableComponent';
+
+type changelogBullet = 'feature' | 'fix' | 'deprecation';
+
+type ChangelogIcon = {
+  BulletIcon: OverridableComponent<SvgIconTypeMap<object, 'svg'>> & {
+    muiName: string;
+  };
+  color: 'info' | 'success' | 'error';
+};
+
+type ChangeLogBulletProps = {
+  type: changelogBullet;
+};
+
+const icons: Record<changelogBullet, ChangelogIcon> = {
+  fix: {
+    BulletIcon: AddCircleIcon,
+    color: 'success',
+  },
+  feature: {
+    BulletIcon: CheckCircleIcon,
+    color: 'info',
+  },
+  deprecation: {
+    BulletIcon: ErrorIcon,
+    color: 'error',
+  },
+};
+
+function ChangelogBullet(props: ChangeLogBulletProps): JSX.Element {
+  const { BulletIcon, color } = icons[props.type];
+
+  return <BulletIcon fontSize="small" color={color} />;
+}
+
+export default ChangelogBullet;

--- a/frontend/src/components/about/ChangelogBullet.tsx
+++ b/frontend/src/components/about/ChangelogBullet.tsx
@@ -20,11 +20,11 @@ type ChangeLogBulletProps = {
 const icons: Record<changelogBullet, ChangelogIcon> = {
   fix: {
     BulletIcon: AddCircleIcon,
-    color: 'success',
+    color: 'info',
   },
   feature: {
     BulletIcon: CheckCircleIcon,
-    color: 'info',
+    color: 'success',
   },
   deprecation: {
     BulletIcon: ErrorIcon,

--- a/frontend/src/components/about/ChangelogList.tsx
+++ b/frontend/src/components/about/ChangelogList.tsx
@@ -24,7 +24,7 @@ function ChangelogList(props: ChangelogListProps): JSX.Element {
 
   return (
     <div className="mb-16">
-      <h3 className="font-bold text-2xl mb-2">{props.heading}</h3>
+      <h3 className="font-bold text-center text-2xl mb-2">{props.heading}</h3>
       <ul>
         {props.items.map((item) => (
           <ChangelogListItem

--- a/frontend/src/components/about/ChangelogList.tsx
+++ b/frontend/src/components/about/ChangelogList.tsx
@@ -1,0 +1,41 @@
+import { changelogBullet } from './ChangelogBullet';
+import ChangelogListItem from './ChangelogListItem';
+
+type ChangelogListProps = {
+  items: string[];
+  heading: string;
+  type: changelogBullet;
+  /**
+   * Prevents duplicate keys if there are features/deprecations/fixes
+   * that happen to have the same content but different versions.
+   */
+  version: string;
+};
+
+/**
+ * Renders a section (features, fixes, or deprecations) of a version's changelog.
+ * If the section has no items (i.e. no features, fixes, or deprecations),
+ * this component does not render anything
+ */
+function ChangelogList(props: ChangelogListProps): JSX.Element {
+  if (props.items.length === 0) {
+    return <></>;
+  }
+
+  return (
+    <div className="mb-16">
+      <h3 className="font-bold text-2xl mb-2">{props.heading}</h3>
+      <ul>
+        {props.items.map((item) => (
+          <ChangelogListItem
+            key={`changelog-list-item-${item}-${props.version}-${props.type}`}
+            text={item}
+            type={props.type}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default ChangelogList;

--- a/frontend/src/components/about/ChangelogListItem.tsx
+++ b/frontend/src/components/about/ChangelogListItem.tsx
@@ -1,0 +1,17 @@
+import ChangelogBullet, { changelogBullet } from './ChangelogBullet';
+
+type ChangelogListItemProps = {
+  type: changelogBullet;
+  text: string;
+};
+
+function ChangelogListItem(props: ChangelogListItemProps): JSX.Element {
+  return (
+    <li className="flex items-center gap-2">
+      <ChangelogBullet type={props.type} />
+      {props.text}
+    </li>
+  );
+}
+
+export default ChangelogListItem;

--- a/frontend/src/components/about/ChangelogListItem.tsx
+++ b/frontend/src/components/about/ChangelogListItem.tsx
@@ -7,7 +7,7 @@ type ChangelogListItemProps = {
 
 function ChangelogListItem(props: ChangelogListItemProps): JSX.Element {
   return (
-    <li className="flex items-center gap-2">
+    <li className="flex mb-4 lg:mb-0 items-center gap-2">
       <ChangelogBullet type={props.type} />
       {props.text}
     </li>

--- a/frontend/src/components/sellListing/ListingTopBar.tsx
+++ b/frontend/src/components/sellListing/ListingTopBar.tsx
@@ -27,6 +27,14 @@ function ListingTopBar() {
           <Link to="#trade" className="p-4 text-gray-900 hover:text-gray-600  text-sm font-medium">
             Trade
           </Link>
+          <Link
+            to="/about"
+            className={`p-4 text-gray-900 hover:text-gray-600  text-sm font-medium ${
+              currentPath.includes('/about') && 'border-b-2 border-stone-500'
+            }`}
+          >
+            About
+          </Link>
         </div>
       </div>
     </div>

--- a/frontend/src/constants/changelogArchive.ts
+++ b/frontend/src/constants/changelogArchive.ts
@@ -1,0 +1,36 @@
+/**
+ * This array is used to render the changelog. For each new version release,
+ * you should simply update the archive and the changelog page will also be updated.
+ *
+ * The versions are ordered by their release dates descending, meaning
+ * that the newest version should be the first element.
+ *
+ * If a version is missing new features, fixes, or deprecations, you
+ * should simply supply an empty array for the respective category.
+ *
+ * The ``version`` should not be prepended by a "v", this will be done by the component itself.
+ */
+export const changelogArchive: readonly ChangelogArchive[] = Object.freeze([
+  {
+    version: '1.0.0',
+    date: 'February 2, 2024',
+    features: ['Basic listings', 'Checkout', 'Profile and settings'],
+    fixes: ['Inconsistent listings', 'Authentication tokens'],
+    deprecated: ['Instant buy'],
+  },
+  {
+    version: '0.9.0',
+    date: 'February 2, 2024',
+    features: ['Basic listings', 'Checkout', 'Profile and settings'],
+    fixes: ['Inconsistent listings', 'Authentication tokens'],
+    deprecated: ['Instant buy'],
+  },
+]);
+
+type ChangelogArchive = {
+  version: string;
+  date: string;
+  features: string[];
+  fixes: string[];
+  deprecated: string[];
+};

--- a/frontend/src/pages/about/Changelog.tsx
+++ b/frontend/src/pages/about/Changelog.tsx
@@ -17,7 +17,7 @@ function Changelog(): JSX.Element {
     <section className="bg-[#F5F5F5] min-h-[100vh]">
       <ListingTopBar />
       <BreadcrumbNavigation links={breadcrumbNavigation} heading="Changelog" />
-      <PageSection className="mt-4 lg:px-12 lg:py-20 w-11/12 lg:w-4/5 mx-auto">
+      <PageSection className="mt-4 lg:px-12 py-4 lg:py-20 w-11/12 lg:w-4/5 mx-auto">
         {changelogArchive.map((milestone, i) => (
           <>
             <section

--- a/frontend/src/pages/about/Changelog.tsx
+++ b/frontend/src/pages/about/Changelog.tsx
@@ -1,0 +1,57 @@
+import { Divider } from '@mui/material';
+import BreadcrumbNavigation, { BreadcrumbLink } from '../../components/BreadcrumbNavigation';
+import PageSection from '../../components/PageSection';
+import ChangelogList from '../../components/about/ChangelogList';
+import ListingTopBar from '../../components/sellListing/ListingTopBar';
+import { changelogArchive } from '../../constants/changelogArchive';
+
+function Changelog(): JSX.Element {
+  const breadcrumbNavigation: BreadcrumbLink[] = [
+    {
+      text: 'About',
+      href: '/about',
+    },
+  ];
+
+  return (
+    <section className="bg-[#F5F5F5] min-h-[100vh]">
+      <ListingTopBar />
+      <BreadcrumbNavigation links={breadcrumbNavigation} heading="Changelog" />
+      <PageSection className="mt-4 px-12 py-20 w-4/5 mx-auto">
+        {changelogArchive.map((milestone, i) => (
+          <>
+            <section className="flex w-3/5 justify-between" key={milestone.version}>
+              <div>
+                <h2 className="font-bold">v{milestone.version}</h2>
+                <span>{milestone.date}</span>
+              </div>
+              <div>
+                <ChangelogList
+                  version={milestone.version}
+                  type="feature"
+                  heading="New features"
+                  items={milestone.features}
+                />
+                <ChangelogList
+                  version={milestone.version}
+                  type="fix"
+                  heading="Fixes"
+                  items={milestone.fixes}
+                />
+                <ChangelogList
+                  version={milestone.version}
+                  type="deprecation"
+                  heading="Deprecated"
+                  items={milestone.deprecated}
+                />
+              </div>
+            </section>
+            {i < changelogArchive.length - 1 ? <Divider sx={{ marginBottom: 4 }} /> : <></>}
+          </>
+        ))}
+      </PageSection>
+    </section>
+  );
+}
+
+export default Changelog;

--- a/frontend/src/pages/about/Changelog.tsx
+++ b/frontend/src/pages/about/Changelog.tsx
@@ -17,13 +17,18 @@ function Changelog(): JSX.Element {
     <section className="bg-[#F5F5F5] min-h-[100vh]">
       <ListingTopBar />
       <BreadcrumbNavigation links={breadcrumbNavigation} heading="Changelog" />
-      <PageSection className="mt-4 px-12 py-20 w-4/5 mx-auto">
+      <PageSection className="mt-4 lg:px-12 lg:py-20 w-11/12 lg:w-4/5 mx-auto">
         {changelogArchive.map((milestone, i) => (
           <>
-            <section className="flex w-3/5 justify-between" key={milestone.version}>
+            <section
+              className="flex items-center lg:w-3/5 flex-col lg:flex-row lg:justify-between"
+              key={milestone.version}
+            >
               <div>
-                <h2 className="font-bold">v{milestone.version}</h2>
-                <span>{milestone.date}</span>
+                <h2 className="text-3xl text-center lg:text-left lg:text-base font-bold">
+                  v{milestone.version}
+                </h2>
+                <div className="text-center mb-8 lg:text-left">{milestone.date}</div>
               </div>
               <div>
                 <ChangelogList

--- a/frontend/src/router/Router.tsx
+++ b/frontend/src/router/Router.tsx
@@ -19,6 +19,7 @@ import EditListing from '../pages/listing/EditListing';
 import { loadListingDetails } from './loadListingDetails/loadEditListingDetails';
 import { loadPublicUserInfo } from './loadPublicUserInfo/loadPublicUserInfo';
 import Cart from '../pages/Cart';
+import Changelog from '../pages/about/Changelog';
 
 const routes = createBrowserRouter([
   {
@@ -60,6 +61,15 @@ const routes = createBrowserRouter([
         path: '/cart',
         element: <Cart />,
         loader: authorizedGuard,
+      },
+      {
+        path: '/about',
+        children: [
+          {
+            path: 'changelog',
+            element: <Changelog />,
+          },
+        ],
       },
       {
         path: '/user/:username',


### PR DESCRIPTION
This PR tackles #57. I am providing [screenshots of the design](https://imgur.com/a/cvk3qY1)

The content in the page is **generated** via an array in ``/src/constants/changelogArchive.ts``. I have left a JSDocs comment in there that explains how to work with it. This means that for every version release, all we have to do is simply update that array and this will be reflected in the page.

I have also made the page responsive. The current mobile design centers the Features/Fixes/Deprecated headings and aligns the bullet points to the left. In the screenshots above, I have also showcased a potential design where the headings are left-aligned as well for better symmetry, so I would appreciate feedback on which design is preferred

This PR also updates the navigation Buy/Search/Trade tabs bar to include a link to the main about page (which doesn't exist currently). With that said, I think it should receive some refactoring since it could potentially use the tabs component provided by MUI rather than use the current custom implementation and I remember even encountering cases where none of the links are selected (though I would need to investigate the steps for reproduction). It would be more appropriate to tackle this in a separate PR and I will likely open an issue regarding this at a later point and then fix it myself.

Let me know if there are any issues