### PR TITLE
Map the node_modules folder from container to host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - cardflow
     volumes:
       - ./frontend:/usr/src/app
-      - /usr/src/app/node_modules
+      - node_modules:/usr/src/app/node_modules
     tty: true
     ports:
       - "5173:5173"
@@ -72,3 +72,11 @@ services:
 networks:
   cardflow:
     driver: bridge
+
+volumes:
+  node_modules:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ./frontend/node_modules


### PR DESCRIPTION
This PR is targeting issue #73 .

To achieve this task  I have used a simple solution by setting the storage location of the volume to correspond with the `node_modules` directory of the **host**. To do this, a named volume with a local driver and a bind mount has been utilized. 

Synchronizing the `node_modules` folder from the *container* to the *host* is established at creating the container with docker compose. Please note that this action is time consuming and it used around 500sec to be created.
>[!NOTE]
> My suggestions is to delete the current node_modules folder and then start this process because otherwise might not sync as intended.

Please test it and let me know if you approve this approach.