### PR TITLE
Backend/future#58 best seller

### DIFF
--- a/backend/cardflow/urls.py
+++ b/backend/cardflow/urls.py
@@ -7,6 +7,8 @@ from rest_framework import permissions
 from accounts.views import ContactFormView
 
 from order.views import FeedbackAndRatingViewSet
+
+from yugioh.views import BestSellerCardListView
 from cardflow import settings
 
 urlpatterns = [
@@ -21,7 +23,8 @@ urlpatterns = [
     path('api/cart/', include('cart.urls')),
     path('api/contacts/', ContactFormView.as_view(), name='contact_form'),
     path('api/feedback/', FeedbackAndRatingViewSet.as_view({'get': 'list', 'post': 'create'}), name='feedback'),
-    path('api/feedback/user/<int:pk>/', FeedbackAndRatingViewSet.as_view({'get': 'retrieve'}),)
+    path('api/feedback/user/<int:pk>/', FeedbackAndRatingViewSet.as_view({'get': 'retrieve'}),),
+    path('bestseller/', BestSellerCardListView.as_view(), name='bestseller'),
 ]
 
 if settings.DEBUG:

--- a/backend/cardflow/urls.py
+++ b/backend/cardflow/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
     path('api/contacts/', ContactFormView.as_view(), name='contact_form'),
     path('api/feedback/', FeedbackAndRatingViewSet.as_view({'get': 'list', 'post': 'create'}), name='feedback'),
     path('api/feedback/user/<int:pk>/', FeedbackAndRatingViewSet.as_view({'get': 'retrieve'}),),
-    path('bestseller/', BestSellerCardListView.as_view(), name='bestseller'),
+    path('api/bestseller/', BestSellerCardListView.as_view(), name='bestseller'),
 ]
 
 if settings.DEBUG:

--- a/backend/order/admin.py
+++ b/backend/order/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.db.models import Sum
 
 from order.filters import AdminListingFilter
 from order.models import Order, OrderItem, FeedbackAndRating
@@ -19,6 +20,7 @@ class OrderAdmin(admin.ModelAdmin):
         'status',
         'get_order_items',
         'delivery_address',
+        'get_quantity',
     )
 
     list_filter = (
@@ -40,6 +42,11 @@ class OrderAdmin(admin.ModelAdmin):
         return ' || '.join([str(listing) for listing in obj.orderitem_set.all()])
 
     get_order_items.short_description = 'Order Items'
+
+    def get_quantity(self, obj):
+        return obj.orderitem_set.aggregate(Sum('quantity'))['quantity__sum']
+
+    get_quantity.short_description = 'Quantity'
 
 
 @admin.register(FeedbackAndRating)

--- a/backend/yugioh/serializers.py
+++ b/backend/yugioh/serializers.py
@@ -1,6 +1,8 @@
+from django.db.models import Min
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from .models import YugiohCard, YugiohCardInSet, YugiohCardSet, YugiohCardRarity
+from listing.models import Listing
 
 
 class YugiohCardSetSerializer(serializers.ModelSerializer):
@@ -18,7 +20,6 @@ class YugiohCardRaritySerializer(serializers.ModelSerializer):
 
 
 class YugiohCardSerializer(serializers.ModelSerializer):
-
     card_in_sets = serializers.SerializerMethodField()
 
     class Meta:
@@ -91,3 +92,22 @@ class YugiohCardInSetSerializer(serializers.ModelSerializer):
         fields = ['id', 'yugioh_card', 'set', 'rarity']
         read_only_fields = ['id', 'rarity', 'set', 'yugioh_card']
         ordering_fields = ['id']
+
+
+class BestSellerCardSerializer(serializers.ModelSerializer):
+    card_name = serializers.CharField(source='card.yugioh_card.card_name')
+    set_name = serializers.CharField(source='card.set.card_set_name')
+    set_code = serializers.CharField(source='card.set.set_code')
+    card_image = serializers.SerializerMethodField()
+    lowest_price = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Listing
+        fields = ['card_name', 'set_name', 'set_code', 'card_image', 'lowest_price']
+
+    def get_card_image(self, obj):
+        return obj.card.yugioh_card.image
+
+    def get_lowest_price(self, obj):
+        lowest_price = Listing.objects.filter(card=obj.card).aggregate(Min('price'))['price__min']
+        return lowest_price

--- a/backend/yugioh/serializers.py
+++ b/backend/yugioh/serializers.py
@@ -105,9 +105,11 @@ class BestSellerCardSerializer(serializers.ModelSerializer):
         model = Listing
         fields = ['card_name', 'set_name', 'set_code', 'card_image', 'lowest_price']
 
-    def get_card_image(self, obj):
+    @staticmethod
+    def get_card_image(obj):
         return obj.card.yugioh_card.image
 
-    def get_lowest_price(self, obj):
+    @staticmethod
+    def get_lowest_price(obj):
         lowest_price = Listing.objects.filter(card=obj.card).aggregate(Min('price'))['price__min']
         return lowest_price

--- a/backend/yugioh/views.py
+++ b/backend/yugioh/views.py
@@ -41,12 +41,20 @@ class YugiohCardInSetViewSet(viewsets.ModelViewSet):
     http_method_names = ['get']
 
 
+@extend_schema(tags=['Best Seller Cards'])
 class BestSellerCardListView(generics.ListAPIView):
+    """
+    Viewset for API endpoint that shows 3 bestseller cards for all times.\n
+    The bestseller card is defined as the card that has been ordered the most.\n
+        - The endpoint is /api/bestseller/
+    """
     serializer_class = BestSellerCardSerializer
     authentication_classes = []
     permission_classes = []
+    pagination_class = None
 
     def get_queryset(self):
+
         top_cards = OrderItem.objects.values('listing__card').annotate(
             order_count=Count('quantity')).order_by('-order_count')[:10]
 


### PR DESCRIPTION
This PR represents the backend part of issue #58 Add best sellers page.

The response to the request looks like this:

```
[
  {
    "card_name": "Salamangreat Almiraj",
    "set_name": "Maximum Gold: El Dorado",
    "set_code": "MGED",
    "card_image": "https://images.ygoprodeck.com/images/cards/60303245.jpg",
    "lowest_price": 4.5
  },
  {
    "card_name": "Solemn Warning",
    "set_name": "Noble Knights of the Round Table Box Set",
    "set_code": "NKRT",
    "card_image": "https://images.ygoprodeck.com/images/cards/84749824.jpg",
    "lowest_price": 5
  },
  {
    "card_name": "Scapegoat",
    "set_name": "Tournament Pack 7",
    "set_code": "TP7",
    "card_image": "https://images.ygoprodeck.com/images/cards/73915051.jpg",
    "lowest_price": 5
  }
]
```

If there is need of any additional information or the provided one contains unnecessary information, please let me know.

The request was tested on forty orders and the execution time was about 30ms on average.
In the future, when the database becomes very large and if the execution time increases significantly, it can be cached by the frontend or the query can be run nightly by a cron job.