### PR TITLE
Make the home page, register page, login page, card / market details table, and not found page responsive

### DIFF
--- a/frontend/src/components/auth/AuthForm.tsx
+++ b/frontend/src/components/auth/AuthForm.tsx
@@ -1,5 +1,7 @@
-import React, { useRef } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+/* eslint-disable @typescript-eslint/quotes */
+// TO-DO: fix conflict in ESLint / Prettier rules and remove the above
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { userService } from '../../services/user/user';
 import {
   SuccessfulAuthenticationResponse,
@@ -11,6 +13,7 @@ import toast from 'react-hot-toast';
 import { toastMessages } from '../../constants/toast';
 import { errorToast } from '../../util/errorToast';
 import { HttpError } from '../../util/HttpError';
+import { Button, Link, TextField } from '@mui/material';
 
 type AuthFormProps = {
   isLogin: boolean;
@@ -24,6 +27,29 @@ type ErrorProps = {
 
 const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
   const { setUser } = useCurrentUser();
+
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [email, setEmail] = useState('');
+
+  function handleUsernameChange(event: React.ChangeEvent<HTMLInputElement>) {
+    event.preventDefault();
+    const value = event.target.value;
+    setUsername(value);
+  }
+
+  function handlePasswordChange(event: React.ChangeEvent<HTMLInputElement>) {
+    event.preventDefault();
+    const value = event.target.value;
+    setPassword(value);
+  }
+
+  function handleEmailChange(event: React.ChangeEvent<HTMLInputElement>) {
+    event.preventDefault();
+    const value = event.target.value;
+    setEmail(value);
+  }
+
   async function authenticaticateUser(id: number, tokens: SuccessfulAuthenticationResponse) {
     localStorage.setItem('accessToken', tokens.access);
     localStorage.setItem('refreshToken', tokens.refresh);
@@ -35,22 +61,18 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
 
   function validate(isLogin: boolean) {
     const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/;
-    if (passwordRef.current === null || passwordRef.current!.value.trim() === '') {
+    if (password.trim() === '') {
       setPasswordError(true);
     } else {
       setPasswordError(false);
     }
-    if (usernameRef.current === null || usernameRef.current!.value.trim() === '') {
+    if (username.trim() === '') {
       setUsernameError(true);
     } else {
       setUsernameError(false);
     }
     if (!isLogin) {
-      if (
-        usernameRef.current === null ||
-        emailRef.current!.value.trim() === '' ||
-        !emailRegex.test(emailRef.current!.value)
-      ) {
+      if (email.trim() === '' || !emailRegex.test(email)) {
         setEmailError(true);
       } else {
         setEmailError(false);
@@ -64,16 +86,16 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
     try {
       let tokens: SuccessfulAuthenticationResponse;
       const loginData: UserLogin = {
-        username: usernameRef.current!.value,
-        password: passwordRef.current!.value,
+        username,
+        password,
       };
       if (isLogin) {
         tokens = await userService.login(loginData);
       } else {
         const formData: UserRegister = {
-          email: emailRef.current!.value,
-          password: passwordRef.current!.value,
-          username: usernameRef.current!.value,
+          email,
+          password,
+          username,
         };
         tokens = await userService.register(formData);
       }
@@ -94,9 +116,6 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
   }
 
   const navigate = useNavigate();
-  const emailRef = useRef<HTMLInputElement>(null);
-  const usernameRef = useRef<HTMLInputElement>(null);
-  const passwordRef = useRef<HTMLInputElement>(null);
 
   const [passwordError, setPasswordError] = React.useState<boolean>(false);
   const [usernameError, setUsernameError] = React.useState<boolean>(false);
@@ -109,47 +128,49 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
         <h2 className="text-4xl text-center font-bold pt-20 pb-10 text-secondary">
           {isLogin ? 'Log in' : 'Sign up'} for Cardflow
         </h2>
-        <input
-          className={`w-3/4 md:w-96 h-8 p-4 mb-4 bg-white rounded-md border ${
-            usernameError && 'border-red-500'
-          } border-primary-border`}
-          placeholder="Username"
-          id="username"
-          ref={usernameRef}
-        />
-        {error.username && <p className="text-red-500">{error.username}</p>}
-        {!isLogin ? (
-          <input
-            className={`w-3/4 md:w-96 h-8 p-4 mb-4 bg-white rounded-md border border-primary-border ${
-              emailError && 'border-red-500'
-            }`}
-            placeholder="Email Address"
-            id="email-address"
-            ref={emailRef}
+        <div className="w-full flex justify-center mb-8">
+          <TextField
+            className="w-3/4 lg:w-96"
+            placeholder="Username"
+            size="small"
+            label={usernameError ? error.username : 'Username'}
+            id="username"
+            error={usernameError}
+            onChange={handleUsernameChange}
           />
+        </div>
+        {!isLogin ? (
+          <div className="w-full flex justify-center mb-8">
+            <TextField
+              size="small"
+              label={emailError ? error.email : 'Email Address'}
+              className="w-3/4 lg:w-96"
+              placeholder="Email Address"
+              id="email-address"
+              error={emailError}
+              onChange={handleEmailChange}
+            />
+          </div>
         ) : null}
-        {error.email && <p className="text-red-500">{error.email}</p>}
-        <input
-          className={`w-3/4 md:w-96 h-8 p-4 bg-white rounded-md border border-primary-border ${
-            passwordError && 'border-red-500'
-          }`}
+        <TextField
+          size="small"
+          label={passwordError ? error.password : 'Password'}
+          className="w-3/4 lg:w-96"
           placeholder="Password"
           type="password"
-          ref={passwordRef}
+          error={passwordError}
+          onChange={handlePasswordChange}
         />
-        {error.password && <p className="text-red-500">{error.password}</p>}
         <div className="flex items-center flex-col mt-4">
-          <button type="submit" className="bg-[#171717] text-white py-1 px-4 rounded-md">
+          <Button type="submit" color="primary" variant="contained" size="large">
             {isLogin ? 'Log in' : 'Sign up'}
-          </button>
+          </Button>
         </div>
         <div className="flex justify-center items-center flex-col py-5">
           <p className="font-extrabold text-center">
-            {isLogin ? 'Don’t have an account?' : 'Already have an account?'}{' '}
-            <Link
-              to={isLogin ? '/register' : '/login'}
-              className="text-[#2384F4] text-lg font-inter font-semibold underline"
-            >
+            {/* eslint-disable-next-line quotes */}
+            {isLogin ? "Don't have an account?" : 'Already have an account?'}{' '}
+            <Link href={isLogin ? '/register' : '/login'} color="#2384F4" underline="hover">
               {isLogin ? 'Sign up' : 'Log in'}
             </Link>
           </p>

--- a/frontend/src/components/auth/AuthForm.tsx
+++ b/frontend/src/components/auth/AuthForm.tsx
@@ -106,11 +106,11 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
   return (
     <form onSubmit={handleSubmitAuthForm}>
       <div className="flex justify-center items-center flex-col">
-        <h2 className="text-4xl font-bold pt-20 pb-10 text-secondary">
+        <h2 className="text-4xl text-center font-bold pt-20 pb-10 text-secondary">
           {isLogin ? 'Log in' : 'Sign up'} for Cardflow
         </h2>
         <input
-          className={`w-96 h-8 p-4 mb-4 bg-white rounded-md border ${
+          className={`w-3/4 md:w-96 h-8 p-4 mb-4 bg-white rounded-md border ${
             usernameError && 'border-red-500'
           } border-primary-border`}
           placeholder="Username"
@@ -120,7 +120,7 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
         {error.username && <p className="text-red-500">{error.username}</p>}
         {!isLogin ? (
           <input
-            className={`w-96 h-8 p-4 mb-4 bg-white rounded-md border border-primary-border ${
+            className={`w-3/4 md:w-96 h-8 p-4 mb-4 bg-white rounded-md border border-primary-border ${
               emailError && 'border-red-500'
             }`}
             placeholder="Email Address"
@@ -130,7 +130,7 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
         ) : null}
         {error.email && <p className="text-red-500">{error.email}</p>}
         <input
-          className={`w-96 h-8 p-4 bg-white rounded-md border border-primary-border ${
+          className={`w-3/4 md:w-96 h-8 p-4 bg-white rounded-md border border-primary-border ${
             passwordError && 'border-red-500'
           }`}
           placeholder="Password"
@@ -144,7 +144,7 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
           </button>
         </div>
         <div className="flex justify-center items-center flex-col py-5">
-          <p className="font-extrabold">
+          <p className="font-extrabold text-center">
             {isLogin ? 'Don’t have an account?' : 'Already have an account?'}{' '}
             <Link
               to={isLogin ? '/register' : '/login'}

--- a/frontend/src/components/auth/AuthForm.tsx
+++ b/frontend/src/components/auth/AuthForm.tsx
@@ -128,7 +128,7 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
         <h2 className="text-4xl text-center font-bold pt-20 pb-10 text-secondary">
           {isLogin ? 'Log in' : 'Sign up'} for Cardflow
         </h2>
-        <div className="w-full flex justify-center mb-4">
+        <div className="w-full flex justify-center mb-8 lg:mb-4">
           <TextField
             className="w-3/4 lg:w-96"
             placeholder="Username"
@@ -140,7 +140,7 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
           />
         </div>
         {!isLogin ? (
-          <div className="w-full flex justify-center mb-4">
+          <div className="w-full flex justify-center mb-8 lg:mb-4">
             <TextField
               size="small"
               label={emailError ? error.email : 'Email Address'}

--- a/frontend/src/components/auth/AuthForm.tsx
+++ b/frontend/src/components/auth/AuthForm.tsx
@@ -128,7 +128,7 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
         <h2 className="text-4xl text-center font-bold pt-20 pb-10 text-secondary">
           {isLogin ? 'Log in' : 'Sign up'} for Cardflow
         </h2>
-        <div className="w-full flex justify-center mb-8">
+        <div className="w-full flex justify-center mb-4">
           <TextField
             className="w-3/4 lg:w-96"
             placeholder="Username"
@@ -140,7 +140,7 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
           />
         </div>
         {!isLogin ? (
-          <div className="w-full flex justify-center mb-8">
+          <div className="w-full flex justify-center mb-4">
             <TextField
               size="small"
               label={emailError ? error.email : 'Email Address'}

--- a/frontend/src/components/yugioh/table/YugiohCardDetailsCell.tsx
+++ b/frontend/src/components/yugioh/table/YugiohCardDetailsCell.tsx
@@ -1,17 +1,29 @@
 import { Typography } from '@mui/material';
+import React from 'react';
 
 type YugiohCardDetailsCellProps = {
   heading: string;
-  data: string | number;
+  data: string | number | React.ReactNode;
 };
 
 function YugiohCardDetailsCell(props: YugiohCardDetailsCellProps): JSX.Element {
   return (
-    <td className="pl-8 pr-8 first:border-r-2 border-t-2 w-1/2">
-      <h3>{props.heading}</h3>
-      <Typography component="p" color="text.secondary">
-        {props.data}
-      </Typography>
+    <td className="px-4 lg:px-8 first:border-r-2 border-t-2 w-1/2">
+      <div className="flex justify-between items-center text-sm lg:text-base lg:block">
+        <h3>{props.heading}</h3>
+        <Typography component="p" className="hidden lg:block" color="text.secondary">
+          {props.data}
+        </Typography>
+        <Typography
+          textAlign="center"
+          component="p"
+          className="block lg:hidden"
+          fontSize={14}
+          color="text.secondary"
+        >
+          {props.data}
+        </Typography>
+      </div>
     </td>
   );
 }

--- a/frontend/src/components/yugioh/table/YugiohCardDetailsTable.tsx
+++ b/frontend/src/components/yugioh/table/YugiohCardDetailsTable.tsx
@@ -7,7 +7,7 @@ type YugiohCardDetailsTableProps = {
 
 function YugiohCardDetailsTable(props: YugiohCardDetailsTableProps): JSX.Element {
   return (
-    <table className="bg-white border-spacing-0 border-separate rounded-lg border-2 w-5/6 lg:w-1/2 h-[300px]">
+    <table className="bg-white border-spacing-0 border-separate rounded-lg border-2 w-11/12 lg:w-1/2 h-[300px]">
       <thead>
         <tr className="text-left">
           <th className="pl-8 pr-8 pt-2 pb-2" colSpan={2}>
@@ -26,7 +26,7 @@ function YugiohCardDetailsTable(props: YugiohCardDetailsTableProps): JSX.Element
         </tr>
         <tr>
           <YugiohCardDetailsCell heading="Rarity" data={props.cardInSet.rarity.rarity} />
-          <YugiohCardDetailsCell heading="30-days average price" data="$ 5.14" />
+          <YugiohCardDetailsCell heading="30-days average price" data={<>$&nbsp;5.14</>} />
         </tr>
       </tbody>
     </table>

--- a/frontend/src/components/yugioh/table/market/AddToCartButton.tsx
+++ b/frontend/src/components/yugioh/table/market/AddToCartButton.tsx
@@ -11,23 +11,48 @@ function AddToCardButton(props: AddToCartButtonProps): JSX.Element {
     return <div aria-hidden={true} className="h-10 w-14 invisible"></div>;
   }
   return (
-    <Button
-      color="success"
-      sx={{
-        backgroundColor: '#15B58D',
-        borderColor: '#3A3A3A',
-        color: 'white',
-        ':hover': {
-          color: 'black',
-        },
-      }}
-      aria-label="Add to cart"
-      size="small"
-      className="border h-10 w-14"
-      onClick={props.onClick}
-    >
-      <ShoppingCartIcon />
-    </Button>
+    <>
+      <div className="hidden lg:block">
+        <Button
+          color="success"
+          sx={{
+            backgroundColor: '#15B58D',
+            borderColor: '#3A3A3A',
+            color: 'white',
+            ':hover': {
+              color: 'black',
+            },
+          }}
+          aria-label="Add to cart"
+          size="small"
+          className="border h-10 w-14"
+          onClick={props.onClick}
+        >
+          <ShoppingCartIcon />
+        </Button>
+      </div>
+      <div className="block lg:hidden">
+        <Button
+          color="success"
+          sx={{
+            backgroundColor: '#15B58D',
+            borderColor: '#3A3A3A',
+            color: 'white',
+            padding: 2,
+            borderRadius: 5,
+            ':hover': {
+              color: 'black',
+            },
+          }}
+          aria-label="Add to cart"
+          size="small"
+          className="border h-5"
+          onClick={props.onClick}
+        >
+          <ShoppingCartIcon />
+        </Button>
+      </div>
+    </>
   );
 }
 

--- a/frontend/src/components/yugioh/table/market/YugiohCardMarket.tsx
+++ b/frontend/src/components/yugioh/table/market/YugiohCardMarket.tsx
@@ -12,14 +12,14 @@ type YugiohCardMarketProps = {
 function YugiohCardMarket(props: YugiohCardMarketProps): JSX.Element {
   return (
     <>
-      <div className="flex flex-col md:items-center justify-center overflow-auto">
+      <div className="hidden lg:flex flex-col md:items-center justify-center overflow-auto">
         <MarketTable
           page={props.page}
           onPageChange={props.onChangePage}
           count={props.count}
           className="w-11/12 md:w-full lg:w-5/6 mb-12"
         >
-          <thead>
+          <thead className="text-sm lg:text-base">
             <tr>
               <th colSpan={3}>Seller</th>
               <th colSpan={2}>Card details</th>
@@ -27,7 +27,29 @@ function YugiohCardMarket(props: YugiohCardMarketProps): JSX.Element {
               <th colSpan={3}>Buy</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody className="text-sm lg:text-base">
+            {props.listings.map((l) => (
+              <YugiohCardMarketTableCell key={l.id} listing={l} />
+            ))}
+          </tbody>
+        </MarketTable>
+      </div>
+      <div className="flex lg:hidden flex-col mx-auto overflow-auto">
+        <MarketTable
+          page={props.page}
+          onPageChange={props.onChangePage}
+          count={props.count}
+          className="w-11/12 mx-auto md:w-5/6 mb-12"
+        >
+          <thead className="text-sm lg:text-base">
+            <tr>
+              <th>Seller</th>
+              <th colSpan={2}>Card details</th>
+              <th>Available</th>
+              <th colSpan={3}>Buy</th>
+            </tr>
+          </thead>
+          <tbody className="text-sm lg:text-base">
             {props.listings.map((l) => (
               <YugiohCardMarketTableCell key={l.id} listing={l} />
             ))}

--- a/frontend/src/components/yugioh/table/market/YugiohCardMarketTableCell.tsx
+++ b/frontend/src/components/yugioh/table/market/YugiohCardMarketTableCell.tsx
@@ -43,13 +43,13 @@ function YugiohCardMarketTableCell(props: YugiohCardMarketTableCellProps): JSX.E
   const cannotBuy = user.user_id === props.listing.user || !isAuthenticated;
   return (
     <tr>
-      <td className="text-center w-16">
+      <td className="hidden lg:table-cell text-center w-16">
         <YugiohSellerRankBadge sales={900} />
       </td>
-      <td className="text-center w-16">
+      <td className="hidden lg:table-cell text-center w-16">
         <YugiohSellerRankLabel sales={900} />
       </td>
-      <td className="text-xl">
+      <td className="text-sm lg:text-xl">
         <Link
           sx={{ color: '#0B70E5' }}
           className="font-bold"
@@ -69,8 +69,8 @@ function YugiohCardMarketTableCell(props: YugiohCardMarketTableCellProps): JSX.E
         />
         <br />
       </td>
-      <td className="text-center text-xl p-1">{props.listing.quantity}</td>
-      <td className="font-bold text-xl w-[200px]">$&nbsp;{props.listing.price}</td>
+      <td className="lg:text-center text-sm lg:text-xl p-1">{props.listing.quantity}</td>
+      <td className="font-bold text-sm lg:text-xl lg:w-[200px]">$&nbsp;{props.listing.price}</td>
       <td className="w-1">
         <YugiohCardQuantityField
           max={props.listing.quantity}

--- a/frontend/src/components/yugioh/table/market/YugiohCardQuantityField.tsx
+++ b/frontend/src/components/yugioh/table/market/YugiohCardQuantityField.tsx
@@ -24,14 +24,14 @@ function YugiohCardQuantityField(props: YugiohCardQuantityFieldProps): JSX.Eleme
     return (
       <div
         aria-hidden={true}
-        className="p-1 w-16 h-10 text-center border rounded-sm invisible"
+        className="p-1 w-12 lg:w-16 h-7 lg:h-10 text-center border rounded-sm invisible"
       ></div>
     );
   }
 
   return (
     <input
-      className="p-1 w-16 h-10 text-center border rounded-sm"
+      className="p-1 w-12 lg:w-16 h-7 lg:h-10 text-center border rounded-sm"
       style={{ borderColor: secondary }}
       type="number"
       onChange={handleChange}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,13 +4,22 @@
 
 body,
 html {
-  min-height: 100%;
   position: relative;
   z-index: 1;
+}
+
+body {
+  min-height: 100vh;
 }
 
 @media (prefers-reduced-motion: no-preference) {
   html {
     scroll-behavior: smooth;
   }
+}
+
+#root {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }

--- a/frontend/src/pages/Home.module.css
+++ b/frontend/src/pages/Home.module.css
@@ -98,9 +98,8 @@
 
 .buttonContainer {
   position: relative;
-  display: inline-block; /* Use 'inline-flex' if you're using flex properties */
-  /* No padding or margins that might create extra space around the button */
 }
+
 
 .buttonContainer::before {
   content: '';

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,18 +1,16 @@
 import { Button, useTheme } from '@mui/material';
 import Logo from '../components/logo/Logo';
-import { useNavigate } from 'react-router-dom';
 import { useAuthenticationStatus } from '../context/user';
 import classes from './Home.module.css';
 
 function Home(): JSX.Element {
-  const navigate = useNavigate();
   const { isAuthenticated } = useAuthenticationStatus();
   const theme = useTheme();
   const secondary = theme.palette.grey['200'];
 
   return (
-    <div className="pt-40 flex justify-center items-center flex-col">
-      <div className="flex">
+    <div className="mt-12 lg:pt-40 pb-4 flex justify-center items-center flex-col">
+      <div className="flex flex-col text-center lg:flex-row">
         <h1 className={`text-7xl font-extrabold pl-4 py-2 text-secondary ${classes.firstWordText}`}>
           Buy.
         </h1>
@@ -31,8 +29,8 @@ function Home(): JSX.Element {
       <p className="text-center text-neutral-500 text-2xl font-normal">
         to move your cards from A to B.
       </p>
-      <div className="flex mt-2 pt-12">
-        <div>
+      <div className="flex gap-8 mt-2 pt-12 flex-col lg:flex-row items-center">
+        <div className="hidden lg:block">
           <Button
             variant="contained"
             sx={{
@@ -42,17 +40,32 @@ function Home(): JSX.Element {
               backgroundColor: 'black',
               height: 47,
             }}
-            className="rounded-[7px]"
             startIcon={<Logo color="white" size={20} />}
             href="/buy"
           >
             Start exploring
           </Button>
         </div>
-        <div className={`ml-12 ${classes.buttonContainer}`}>
+        <div className="block lg:hidden">
+          <Button
+            variant="contained"
+            sx={{
+              padding: '24px',
+              fontSize: 16,
+              textTransform: 'none',
+              backgroundColor: 'black',
+              height: 60,
+            }}
+            startIcon={<Logo color="white" size={25} />}
+            href="/buy"
+          >
+            Start exploring
+          </Button>
+        </div>
+        <div className={`hidden lg:block ${classes.buttonContainer}`}>
           {!isAuthenticated && (
             <Button
-              onClick={() => navigate('/login')}
+              href="/login"
               variant="contained"
               sx={{
                 fontWeight: 'bold',
@@ -62,10 +75,35 @@ function Home(): JSX.Element {
                 padding: '10px',
                 textTransform: 'none',
                 border: '0.5px solid #666',
-                borderRadius: '7px',
                 ':hover': {
                   backgroundColor: secondary,
                 },
+                height: 47,
+              }}
+              className="hover:bg-gray-200"
+            >
+              Sign In
+            </Button>
+          )}
+        </div>
+        <div className={`block lg:hidden ${classes.buttonContainer}`}>
+          {!isAuthenticated && (
+            <Button
+              href="/login"
+              variant="contained"
+              sx={{
+                fontWeight: 'bold',
+                backgroundColor: 'white',
+                color: '#666666',
+                width: 170,
+                padding: '24px',
+                fontSize: 16,
+                textTransform: 'none',
+                border: '0.5px solid #666',
+                ':hover': {
+                  backgroundColor: secondary,
+                },
+                height: 60,
               }}
               className="hover:bg-gray-200"
             >

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -9,29 +9,13 @@ import {
 import Navigation from '../components/navigation/Navigation';
 import { linkBehaviorConfiguration } from '../linkBehaviorConfiguration';
 import { useMemo } from 'react';
+import { theme } from '../constants/theme';
 
 function NotFound(): JSX.Element {
-  const theme = useMemo(
+  const appTheme = useMemo(
     () =>
       createTheme({
-        palette: {
-          primary: {
-            main: '#000',
-          },
-          secondary: {
-            main: '#15B58D',
-          },
-          info: {
-            main: '#000',
-          },
-          text: {
-            primary: '#000',
-            secondary: '#666666',
-          },
-          warning: {
-            main: '#F73378',
-          },
-        },
+        ...theme,
         ...linkBehaviorConfiguration,
       }),
     [],
@@ -39,7 +23,7 @@ function NotFound(): JSX.Element {
 
   return (
     <>
-      <ThemeProvider theme={theme}>
+      <ThemeProvider theme={appTheme}>
         <CssBaseline />
         <Navigation />
         <main className="flex flex-grow justify-center">

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,4 +1,11 @@
-import { Button, CssBaseline, ThemeProvider, Typography, createTheme } from '@mui/material';
+import {
+  Button,
+  CssBaseline,
+  Divider,
+  ThemeProvider,
+  Typography,
+  createTheme,
+} from '@mui/material';
 import Navigation from '../components/navigation/Navigation';
 import { linkBehaviorConfiguration } from '../linkBehaviorConfiguration';
 import { useMemo } from 'react';
@@ -35,20 +42,18 @@ function NotFound(): JSX.Element {
       <ThemeProvider theme={theme}>
         <CssBaseline />
         <Navigation />
-        <main>
-          <section className="flex justify-center flex-col text-center gap-3">
-            <h1 className="text-2xl md:text-3xl lg:text-5xl">
-              The page you are looking for does not exist!
-            </h1>
-            <Typography color="text.secondary" component="p">
-              Make sure that you have spelled the address correctly
-            </Typography>
+        <main className="flex flex-grow justify-center">
+          <section className="flex items-center justify-center flex-col text-center gap-3">
+            <div className="flex items-center justify-center gap-4">
+              <h1 className="text-2xl md:text-3xl lg:text-5xl">404</h1>
+              <Divider orientation="vertical" flexItem />
+              <Typography component="p">This page could not be found</Typography>
+            </div>
             <Button
               sx={{ width: 250, margin: '0 auto' }}
               variant="contained"
               color="primary"
               href="/"
-              className="margin-center"
             >
               Back to home page
             </Button>

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -27,10 +27,15 @@ function NotFound(): JSX.Element {
         <CssBaseline />
         <Navigation />
         <main className="flex flex-grow justify-center">
-          <section className="flex items-center justify-center flex-col text-center gap-8">
-            <div className="flex items-center justify-center gap-4">
-              <h1 className="text-2xl md:text-3xl lg:text-5xl">404</h1>
-              <Divider orientation="vertical" flexItem />
+          <section className="flex items-center justify-center flex-col text-center gap-4 lg:gap-8">
+            <div className="flex items-center flex-col lg:flex-row justify-center lg:gap-4">
+              <h1 className="text-2xl md:text-3xl lg:text-5xl mb-0 pb-0">404</h1>
+              <Divider
+                orientation="vertical"
+                flexItem
+                sx={{ borderRight: 3, borderColor: 'gray' }}
+                className="hidden lg:block"
+              />
               <Typography component="p">This page could not be found</Typography>
             </div>
             <Button

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -43,7 +43,7 @@ function NotFound(): JSX.Element {
         <CssBaseline />
         <Navigation />
         <main className="flex flex-grow justify-center">
-          <section className="flex items-center justify-center flex-col text-center gap-3">
+          <section className="flex items-center justify-center flex-col text-center gap-8">
             <div className="flex items-center justify-center gap-4">
               <h1 className="text-2xl md:text-3xl lg:text-5xl">404</h1>
               <Divider orientation="vertical" flexItem />

--- a/frontend/src/pages/yugioh/BestSellers.tsx
+++ b/frontend/src/pages/yugioh/BestSellers.tsx
@@ -61,7 +61,9 @@ export default function BestSellers() {
       <PageHeader heading="Buy" />
       <div className="w-5/6 mx-auto my-4">
         <PageSection className="p-8 my-4">
-          <Typography variant="h4">All-time best sellers</Typography>
+          <Typography variant="h4" className="text-center lg:text-left">
+            All-time best sellers
+          </Typography>
           <hr />
           <section className="max-sm:flex-col gap-4 mt-6 flex justify-between">
             {cardSection}


### PR DESCRIPTION
This PR is part of my efforts to implement some of the mobile Figma wireframes. This PR focuses on a few basic pages, which have been combined in one PR as the changes are of a trivial nature. [Review the UI](https://imgur.com/a/3DyLlIA)

edit: this also features a super minor change to the best sellers page, which involves just centering the text on mobile.

The login and register pages have also been updated with MUI components.

The not found page has been made to look more like the wireframes (I will admit that, up until recently, I hadn't even known that we had specific wireframes for the page). I have left the home link intact as to provide some convenient escape hatch for the user.

Note to myself: improve client-side validation on login and register pages some other time

Let me know if there any issues