### PR TITLE
Display an error if the username already exists and use client-side validation where possible

### DIFF
--- a/frontend/src/components/auth/AuthForm.tsx
+++ b/frontend/src/components/auth/AuthForm.tsx
@@ -105,8 +105,6 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
       const payload = userService.extractUserFromToken(tokens.access);
       await authenticaticateUser(payload.user_id, tokens);
     } catch (error: any) {
-      // const data = await error.err.json();
-      // setError(data);
       if (error instanceof HttpError) {
         if (isLogin && error.err.status === 401) {
           errorToast(error, toastMessages.error.failedLogin);

--- a/frontend/src/components/auth/AuthForm.tsx
+++ b/frontend/src/components/auth/AuthForm.tsx
@@ -13,7 +13,7 @@ import toast from 'react-hot-toast';
 import { toastMessages } from '../../constants/toast';
 import { errorToast } from '../../util/errorToast';
 import { HttpError } from '../../util/HttpError';
-import { Button, Link, TextField, Typography } from '@mui/material';
+import { Button, Link, TextField } from '@mui/material';
 import { userValidator } from '../../validators/user';
 import { useDebounce } from '../../util/useDebounce';
 
@@ -36,7 +36,7 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
   const debouncedPasswordStatusChange = useDebounce(() => setPasswordFieldWasChanged(true));
   const debouncedEmailStatusChange = useDebounce(() => setEmailFieldWasChanged(true));
 
-  const usernameErrors = userValidator.validateUsername(username);
+  const [usernameErrors, setUsernameErrors] = useState<string[]>([]);
   const passwordErrors = userValidator.validatePassword(password);
   const emailErrors = userValidator.validateEmail(email);
 
@@ -48,12 +48,11 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
 
   const submitButtonIsDisabled = !usernameIsValid || !passwordIsValid || !emailIsValid;
 
-  const [otherErrors, setOtherErrors] = useState<string[]>([]);
-
   function handleUsernameChange(event: React.ChangeEvent<HTMLInputElement>) {
     event.preventDefault();
     const value = event.target.value;
     setUsername(value);
+    setUsernameErrors(userValidator.validateUsername(value));
 
     debouncedUsernameStatusChange();
   }
@@ -114,7 +113,7 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
           } else {
             const errors = await error.err.json();
             if (errors.username && Array.isArray(errors.username)) {
-              setOtherErrors(errors.username);
+              setUsernameErrors(errors.username);
             }
           }
         }
@@ -181,11 +180,6 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
             </Link>
           </p>
         </div>
-        {otherErrors.map((e) => (
-          <Typography color="error" key={e}>
-            {e}
-          </Typography>
-        ))}
       </div>
     </form>
   );

--- a/frontend/src/components/auth/AuthForm.tsx
+++ b/frontend/src/components/auth/AuthForm.tsx
@@ -14,15 +14,11 @@ import { toastMessages } from '../../constants/toast';
 import { errorToast } from '../../util/errorToast';
 import { HttpError } from '../../util/HttpError';
 import { Button, Link, TextField } from '@mui/material';
+import { userValidator } from '../../validators/user';
+import { useDebounce } from '../../util/useDebounce';
 
 type AuthFormProps = {
   isLogin: boolean;
-};
-
-type ErrorProps = {
-  username?: string;
-  email?: string;
-  password?: string;
 };
 
 const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
@@ -32,22 +28,47 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
   const [password, setPassword] = useState('');
   const [email, setEmail] = useState('');
 
+  const [usernameFieldWasChanged, setUsernameFieldWasChanged] = useState(false);
+  const [passwordFieldWasChanged, setPasswordFieldWasChanged] = useState(false);
+  const [emailFieldWasChanged, setEmailFieldWasChanged] = useState(false);
+  const debouncedFieldStatusChange = useDebounce((callback: typeof setUsernameFieldWasChanged) => {
+    callback(true);
+  });
+
+  const usernameErrors = userValidator.validateUsername(username);
+  const passwordErrors = userValidator.validatePassword(password);
+  const emailErrors = userValidator.validateEmail(email);
+
+  const navigate = useNavigate();
+
+  const usernameIsValid = usernameErrors.length === 0 && usernameFieldWasChanged;
+  const passwordIsValid = passwordErrors.length === 0 && passwordFieldWasChanged;
+  const emailIsValid = (emailErrors.length === 0 && emailFieldWasChanged) || isLogin;
+
+  const submitButtonIsDisabled = !usernameIsValid || !passwordIsValid || !emailIsValid;
+
   function handleUsernameChange(event: React.ChangeEvent<HTMLInputElement>) {
     event.preventDefault();
     const value = event.target.value;
     setUsername(value);
+
+    debouncedFieldStatusChange(setUsernameFieldWasChanged);
   }
 
   function handlePasswordChange(event: React.ChangeEvent<HTMLInputElement>) {
     event.preventDefault();
     const value = event.target.value;
     setPassword(value);
+
+    debouncedFieldStatusChange(setPasswordFieldWasChanged);
   }
 
   function handleEmailChange(event: React.ChangeEvent<HTMLInputElement>) {
     event.preventDefault();
     const value = event.target.value;
     setEmail(value);
+
+    debouncedFieldStatusChange(setEmailFieldWasChanged);
   }
 
   async function authenticaticateUser(id: number, tokens: SuccessfulAuthenticationResponse) {
@@ -59,30 +80,8 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
     toast.success(isLogin ? toastMessages.success.login : toastMessages.success.register);
   }
 
-  function validate(isLogin: boolean) {
-    const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/;
-    if (password.trim() === '') {
-      setPasswordError(true);
-    } else {
-      setPasswordError(false);
-    }
-    if (username.trim() === '') {
-      setUsernameError(true);
-    } else {
-      setUsernameError(false);
-    }
-    if (!isLogin) {
-      if (email.trim() === '' || !emailRegex.test(email)) {
-        setEmailError(true);
-      } else {
-        setEmailError(false);
-      }
-    }
-  }
-
   async function handleSubmitAuthForm(event: React.FormEvent) {
     event.preventDefault();
-    validate(isLogin);
     try {
       let tokens: SuccessfulAuthenticationResponse;
       const loginData: UserLogin = {
@@ -103,8 +102,8 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
       const payload = userService.extractUserFromToken(tokens.access);
       await authenticaticateUser(payload.user_id, tokens);
     } catch (error: any) {
-      const data = await error.err.json();
-      setError(data);
+      // const data = await error.err.json();
+      // setError(data);
       if (error instanceof HttpError) {
         if (isLogin && error.err.status === 401) {
           errorToast(error, toastMessages.error.failedLogin);
@@ -114,13 +113,6 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
       }
     }
   }
-
-  const navigate = useNavigate();
-
-  const [passwordError, setPasswordError] = React.useState<boolean>(false);
-  const [usernameError, setUsernameError] = React.useState<boolean>(false);
-  const [emailError, setEmailError] = React.useState<boolean>(false);
-  const [error, setError] = React.useState<ErrorProps>({});
 
   return (
     <form onSubmit={handleSubmitAuthForm}>
@@ -133,9 +125,9 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
             className="w-3/4 lg:w-96"
             placeholder="Username"
             size="small"
-            label={usernameError ? error.username : 'Username'}
+            label={!usernameIsValid && usernameFieldWasChanged ? usernameErrors[0] : 'Username'}
             id="username"
-            error={usernameError}
+            error={!usernameIsValid && usernameFieldWasChanged}
             onChange={handleUsernameChange}
           />
         </div>
@@ -143,26 +135,32 @@ const SignUpPage: React.FC<AuthFormProps> = ({ isLogin }) => {
           <div className="w-full flex justify-center mb-8 lg:mb-4">
             <TextField
               size="small"
-              label={emailError ? error.email : 'Email Address'}
+              label={!emailIsValid && emailFieldWasChanged ? emailErrors[0] : 'Email Address'}
               className="w-3/4 lg:w-96"
               placeholder="Email Address"
               id="email-address"
-              error={emailError}
+              error={!emailIsValid && emailFieldWasChanged}
               onChange={handleEmailChange}
             />
           </div>
         ) : null}
         <TextField
           size="small"
-          label={passwordError ? error.password : 'Password'}
+          label={!passwordIsValid && passwordFieldWasChanged ? passwordErrors[0] : 'Password'}
           className="w-3/4 lg:w-96"
           placeholder="Password"
           type="password"
-          error={passwordError}
+          error={!passwordIsValid && passwordFieldWasChanged}
           onChange={handlePasswordChange}
         />
         <div className="flex items-center flex-col mt-4">
-          <Button type="submit" color="primary" variant="contained" size="large">
+          <Button
+            disabled={submitButtonIsDisabled}
+            type="submit"
+            color="primary"
+            variant="contained"
+            size="large"
+          >
             {isLogin ? 'Log in' : 'Sign up'}
           </Button>
         </div>

--- a/frontend/src/constants/validationErrorMessages/email.ts
+++ b/frontend/src/constants/validationErrorMessages/email.ts
@@ -1,0 +1,7 @@
+import { emailValidationRules } from '../validationRules/email';
+
+export const emailValidationErrorMessages = Object.freeze({
+  minLength: 'Email is required',
+  maxLength: `Email must be no longer than ${emailValidationRules.maxLength} characters`,
+  pattern: 'Invalid email',
+});

--- a/frontend/src/constants/validationErrorMessages/password.ts
+++ b/frontend/src/constants/validationErrorMessages/password.ts
@@ -1,0 +1,6 @@
+import { passwordValidationRules } from '../validationRules/password';
+
+export const passwordValidationErrorMessages = Object.freeze({
+  maxLength: `Password must be no longer than ${passwordValidationRules.maxLength} characters`,
+  minLength: 'Password is required',
+});

--- a/frontend/src/constants/validationErrorMessages/username.ts
+++ b/frontend/src/constants/validationErrorMessages/username.ts
@@ -1,0 +1,7 @@
+import { usernameValidationRules } from '../validationRules/username';
+
+export const usernameValidationErrorMessages = Object.freeze({
+  maxLength: `Username must be no longer than ${usernameValidationRules.maxLength} characters`,
+  minLength: 'Username is required',
+  pattern: 'The username contains an invalid character',
+});

--- a/frontend/src/constants/validationRules/email.ts
+++ b/frontend/src/constants/validationRules/email.ts
@@ -1,0 +1,5 @@
+export const emailValidationRules = Object.freeze({
+  maxLength: 254,
+  minLength: 1,
+  pattern: /^[a-z0-9._-]+@[a-z0-9.-]+\.[a-z]{2,6}$/i,
+});

--- a/frontend/src/constants/validationRules/password.ts
+++ b/frontend/src/constants/validationRules/password.ts
@@ -1,0 +1,4 @@
+export const passwordValidationRules = Object.freeze({
+  minLength: 1,
+  maxLength: 128,
+});

--- a/frontend/src/constants/validationRules/username.ts
+++ b/frontend/src/constants/validationRules/username.ts
@@ -1,0 +1,5 @@
+export const usernameValidationRules = Object.freeze({
+  maxLength: 150,
+  pattern: /^[\w.@+-]+$/,
+  minLength: 1,
+});

--- a/frontend/src/util/useDebounce.ts
+++ b/frontend/src/util/useDebounce.ts
@@ -26,15 +26,15 @@ function debounce<T extends (...args: any[]) => ReturnType<T>>(
  * @param timeout expressed in miliseconds, defaults to 500
  */
 export const useDebounce = (callback: (...args: any[]) => void, timeout = 500) => {
-  const ref = useRef(() => {});
+  const ref = useRef<(...args: any[]) => void>();
 
   useEffect(() => {
     ref.current = callback;
   }, [callback]);
 
   const debouncedCallback = useMemo(() => {
-    const func = () => {
-      ref.current?.();
+    const func = (...args: any[]) => {
+      ref.current?.(...args);
     };
     return debounce(func, timeout);
   }, []);

--- a/frontend/src/validators/user.ts
+++ b/frontend/src/validators/user.ts
@@ -1,0 +1,74 @@
+import { emailValidationErrorMessages } from '../constants/validationErrorMessages/email';
+import { passwordValidationErrorMessages } from '../constants/validationErrorMessages/password';
+import { usernameValidationErrorMessages } from '../constants/validationErrorMessages/username';
+import { emailValidationRules } from '../constants/validationRules/email';
+import { passwordValidationRules } from '../constants/validationRules/password';
+import { usernameValidationRules } from '../constants/validationRules/username';
+
+type userErrorMessage = string;
+
+export const userValidator = {
+  validateUsername(username: string): userErrorMessage[] {
+    username = username.trim();
+    const errorMessages: userErrorMessage[] = [];
+
+    const minLengthIsValid = username.length >= usernameValidationRules.minLength;
+    const maxLengthIsValid = username.length <= usernameValidationRules.maxLength;
+    const patternIsValid = usernameValidationRules.pattern.test(username);
+
+    if (!minLengthIsValid) {
+      errorMessages.push(usernameValidationErrorMessages.minLength);
+    }
+
+    if (!maxLengthIsValid) {
+      errorMessages.push(usernameValidationErrorMessages.maxLength);
+    }
+
+    if (!patternIsValid) {
+      errorMessages.push(usernameValidationErrorMessages.pattern);
+    }
+
+    return errorMessages;
+  },
+
+  validatePassword(password: string): userErrorMessage[] {
+    password = password.trim();
+    const errorMessages: userErrorMessage[] = [];
+
+    const minLengthIsValid = password.length >= passwordValidationRules.minLength;
+    const maxLengthIsValid = password.length <= passwordValidationRules.maxLength;
+
+    if (!minLengthIsValid) {
+      errorMessages.push(passwordValidationErrorMessages.minLength);
+    }
+
+    if (!maxLengthIsValid) {
+      errorMessages.push(passwordValidationErrorMessages.maxLength);
+    }
+
+    return errorMessages;
+  },
+
+  validateEmail(email: string): userErrorMessage[] {
+    email = email.trim();
+    const errorMessages: userErrorMessage[] = [];
+
+    const minLengthIsValid = email.length >= emailValidationRules.minLength;
+    const maxLengthIsValid = email.length <= emailValidationRules.maxLength;
+    const patternIsValid = emailValidationRules.pattern.test(email);
+
+    if (!minLengthIsValid) {
+      errorMessages.push(emailValidationErrorMessages.minLength);
+    }
+
+    if (!maxLengthIsValid) {
+      errorMessages.push(emailValidationErrorMessages.maxLength);
+    }
+
+    if (!patternIsValid) {
+      errorMessages.push(emailValidationErrorMessages.pattern);
+    }
+
+    return errorMessages;
+  },
+};


### PR DESCRIPTION
This PR tackles #95, with two caveats:
- as I mentioned in the linked issue, only some of the validations were performed on the client, the rest relied on the server
- I mentioned in #93 that I wanted at some point to improve the way validation was done on those pages for better UX and decided to do it now.

The reason for this is that there is no point in sending an invalid registration to the server. The validations also apply in the login page for similar reasons. The submit button is disabled when any of the fields are invalid or when at least one field has not been changed at all (inputting anything in a field will cause a debounced status update, which makes the field "dirty").

The only validation that is not performed client-side is for whether the username is already in use, as there is no way to check that before sending the request (in the case of the register page).

If the username is already in use, the error is placed in the username error, though a simple input change will clear it off.

**Note 1:** the email pattern used on the front end likely doesn't completely match the one that comes straight out of Django. The only reason I haven't tried to make them consistent is because it seems like Django performs multiple regex tests on the email and this would require some tweaking on my end. Whether this is worth doing is a different question (since all of the common email domains I could think of are valid in both cases), but in case it is, consider my current implementation more of a partial POC at this stage.

**Note 2:** this PR features a small change to the debounce hook, which makes it possible to pass arguments to the generated function. The reason for this is that I wanted to use one hook for multiple status changes (in regards to whether a particular field has been changed or not) out of laziness, but this ended up causing issues in the cases where a user fills multiple fields very quickly (in which case it did not update all fields' status), so I had to abandon this idea. So basically, there's a small change in the debounce hook that ended up totally irrelevant to the issue at hand.

**Note 3:** I haven't applied any of this in the profile page, since I want to make sure that my approach is fine before I touch that page.