### PR TITLE
Download and Save images locally

### DIFF
--- a/backend/cart/tests/test_shopping_cart.py
+++ b/backend/cart/tests/test_shopping_cart.py
@@ -91,15 +91,16 @@ class ShoppingCartItemViewSetTestCase(TestCase):
 
         actual_cart_items = ShoppingCartItem.objects.filter(cart__user=self.user2)
 
-        serializer = ShoppingCartItemSerializer(actual_cart_items, many=True)
-        actual_data = {
+        serializer = ShoppingCartItemSerializer(actual_cart_items, many=True,
+                                                context={'request': response.wsgi_request})
+        expected_data = {
             'count': actual_cart_items.count(),
             'next': None,
             'previous': None,
             'results': serializer.data,
         }
 
-        self.assertEqual(data, actual_data)
+        self.assertEqual(data, expected_data)
         self.assertEqual(response.status_code, 200)
 
     def test_checkout(self):

--- a/backend/yugioh/management/commands/img_download.py
+++ b/backend/yugioh/management/commands/img_download.py
@@ -1,0 +1,126 @@
+import logging
+import os
+import time
+
+import requests
+from django.core.management.base import BaseCommand
+
+log_filename = "yugioh_image.log"
+logging.basicConfig(filename=log_filename, level=logging.INFO,
+                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+
+class Command(BaseCommand):
+    help = """
+    Download YUGIOH card images from an external API.
+
+    This management command fetches YUGIOH card images from an external API and saves them locally.
+
+    Available commands:
+      - onecard: Download images for a specific card (e.g., "Dark Magician").
+      - staple: Download images for staple cards.
+      - all: Download images for all YUGIOH cards.
+
+    Usage:
+      python manage.py download_images <command>
+
+    Example:
+      python manage.py download_images onecard
+    """
+
+    # API_URLS = {
+    #     'onecard': "https://images.ygoprodeck.com/images/cards/55144522.jpg",
+    #     'staple': "https://db.ygoprodeck.com/api/v7/cardinfo.php?staple=yes",
+    #     # 'all': "https://db.ygoprodeck.com/api/v7/cardinfo.php",
+    # }
+
+    API_URLS = {
+        'onecard': "https://db.ygoprodeck.com/api/v7/cardinfo.php?name=Dark Magician",
+        'staple': "https://db.ygoprodeck.com/api/v7/cardinfo.php?staple=yes",
+        'all': "https://db.ygoprodeck.com/api/v7/cardinfo.php",
+    }
+
+    IMAGE_SAVE_PATH = "media/yugioh_card_images"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'command',
+            type=str,
+            choices=['onecard', 'staple', 'all'],
+            help='Type of images to download'
+        )
+
+    def handle(self, *args, **options):
+
+        api_url = self.API_URLS.get(options['command'])
+
+        if not api_url:
+            self.stdout.write(self.style.ERROR(f'Invalid command: {options["command"]}. Please check help options.'))
+            logging.error(f'Invalid command: {options["command"]}. Please check help options.')
+            return
+
+        response = requests.get(api_url)
+
+        if response.status_code == 200:
+            self.stdout.write(f'For {api_url} -> response code {response.status_code} OK')
+            logging.info(f'For {api_url} -> response code {response.status_code} OK')
+            data = response.json()
+        else:
+            self.stdout.write(self.style.ERROR(f'API request failed with status code {response.status_code}'))
+            logging.error(f'API request FAILED with status code {response.status_code} for {api_url}')
+            return
+
+        for item in data['data']:
+            start_time = time.time()
+
+            try:
+                image_url = item['card_images'][0]['image_url']
+            except (KeyError, IndexError):
+                image_url = "NULL"
+                #                 self.stdout.write('KeyError or IndexError for image')
+                logging.info('KeyError or IndexError for image')
+
+            if image_url == 'NULL':
+                self.stdout.write(f'For {item.get("name")} -> no image')
+                logging.error(f'For {item.get("name")} -> no image')
+                continue
+
+            self.stdout.write(f'Calling the external API - {image_url}')
+            logging.info(f'Calling the external API - {image_url}')
+
+            headers = {"User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0",
+                       "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                       "Accept-Language": "en-US,en;q=0.9"
+                       }
+
+            image_response = requests.get(image_url, headers=headers, stream=True)
+
+            image_name = image_url.split('/')[-1]
+
+            if image_response.status_code == 200:
+                if not os.path.exists(self.IMAGE_SAVE_PATH):
+                    os.makedirs(self.IMAGE_SAVE_PATH)
+
+                image_filename = os.path.join(self.IMAGE_SAVE_PATH, image_name)
+
+                with open(image_filename, 'wb') as handler:
+                    for chunk in image_response.iter_content(chunk_size=8192):
+                        handler.write(chunk)
+
+                self.stdout.write(f'Downloaded image from {image_url} and saved as {image_filename}')
+                logging.info(f'Downloaded image from {image_url} and saved as {image_filename}')
+            else:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f'Failed to download image from {image_url} with status code {image_response.status_code}'))
+                logging.error(
+                    f'Failed to download image from {image_url} with status code {image_response.status_code}')
+
+            end_time = time.time()
+            elapsed_time = end_time - start_time
+            self.stdout.write(f"Elapsed time: {elapsed_time}")
+
+            if elapsed_time < 1:
+                self.stdout.write(f"Waiting: {1 - elapsed_time} before next call")
+                time.sleep(1 - elapsed_time)
+

--- a/backend/yugioh/management/commands/img_download.py
+++ b/backend/yugioh/management/commands/img_download.py
@@ -28,12 +28,6 @@ class Command(BaseCommand):
       python manage.py download_images onecard
     """
 
-    # API_URLS = {
-    #     'onecard': "https://images.ygoprodeck.com/images/cards/55144522.jpg",
-    #     'staple': "https://db.ygoprodeck.com/api/v7/cardinfo.php?staple=yes",
-    #     # 'all': "https://db.ygoprodeck.com/api/v7/cardinfo.php",
-    # }
-
     API_URLS = {
         'onecard': "https://db.ygoprodeck.com/api/v7/cardinfo.php?name=Dark Magician",
         'staple': "https://db.ygoprodeck.com/api/v7/cardinfo.php?staple=yes",
@@ -123,4 +117,3 @@ class Command(BaseCommand):
             if elapsed_time < 1:
                 self.stdout.write(f"Waiting: {1 - elapsed_time} before next call")
                 time.sleep(1 - elapsed_time)
-

--- a/backend/yugioh/serializers.py
+++ b/backend/yugioh/serializers.py
@@ -14,6 +14,10 @@ class CacheImageMixin:
             return None
 
         image_path = fetch_and_save_image(obj.image)
+
+        if image_path is None:
+            return obj.image
+
         return request.build_absolute_uri(image_path)
 
 

--- a/backend/yugioh/serializers.py
+++ b/backend/yugioh/serializers.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 
 from listing.models import Listing
 from .models import YugiohCard, YugiohCardInSet, YugiohCardSet, YugiohCardRarity
-from .utils import fetch_and_save_image
+from .utils import fetch_and_save_image, ImageFetchException
 
 
 class CacheImageMixin:
@@ -15,14 +15,14 @@ class CacheImageMixin:
         request = self.context.get('request')
         if not request:
             return None
+        try:
+            image_path = fetch_and_save_image(obj.image)
 
-        image_path = fetch_and_save_image(obj.image)
-
-        if image_path is None:
+        except ImageFetchException as e:
+            print(e)
             return obj.image
 
         return request.build_absolute_uri(image_path)
-
 
 
 class YugiohCardSetSerializer(serializers.ModelSerializer):

--- a/backend/yugioh/serializers.py
+++ b/backend/yugioh/serializers.py
@@ -7,6 +7,7 @@ from .models import YugiohCard, YugiohCardInSet, YugiohCardSet, YugiohCardRarity
 from .utils import fetch_and_save_image
 
 
+
 class YugiohCardSetSerializer(serializers.ModelSerializer):
     class Meta:
         model = YugiohCardSet
@@ -70,14 +71,15 @@ class YugiohCardSerializer(serializers.ModelSerializer):
 
         return card_in_sets
 
-    @staticmethod
     @extend_schema_field(YugiohCardSetSerializer)
-    def get_image(obj):
+    def get_image(self, obj):
+        request = self.context.get('request')
+        if not request:
+            return None
 
-        local_image_url = fetch_and_save_image(obj.image)
+        image_path = fetch_and_save_image(obj.image)
 
-        return local_image_url
-
+        return request.build_absolute_uri(image_path)
 
 class YugiohCardInSetCardSerializer(YugiohCardSerializer):
     class Meta(YugiohCardSerializer.Meta):
@@ -108,11 +110,15 @@ class YugiohCardInSetSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "rarity", "set", "yugioh_card"]
         ordering_fields = ["id"]
 
-    @staticmethod
     @extend_schema_field(YugiohCardSetSerializer)
-    def get_image(obj):
+    def get_image(self, obj):
+        request = self.context.get('request')
+        if not request:
+            return None
 
-        return fetch_and_save_image(obj.image)
+        image_path = fetch_and_save_image(obj.image)
+
+        return request.build_absolute_uri(image_path)
 
 class BestSellerCardSerializer(serializers.ModelSerializer):
     card_name = serializers.CharField(source="card.yugioh_card.card_name")
@@ -132,9 +138,15 @@ class BestSellerCardSerializer(serializers.ModelSerializer):
             "card_id",
         ]
 
-    @staticmethod
-    def get_card_image(obj):
-        return fetch_and_save_image(obj.card.yugioh_card.image)
+    @extend_schema_field(YugiohCardSetSerializer)
+    def get_card_image(self, obj):
+        request = self.context.get('request')
+        if not request:
+            return None
+
+        image_path = fetch_and_save_image(obj.card.yugioh_card.image)
+
+        return request.build_absolute_uri(image_path)
 
     @staticmethod
     def get_lowest_price(obj):

--- a/backend/yugioh/serializers.py
+++ b/backend/yugioh/serializers.py
@@ -8,6 +8,9 @@ from .utils import fetch_and_save_image
 
 
 class CacheImageMixin:
+    def __init__(self):
+        self.context = None
+
     def get_image(self, obj):
         request = self.context.get('request')
         if not request:

--- a/backend/yugioh/utils.py
+++ b/backend/yugioh/utils.py
@@ -1,0 +1,38 @@
+import os
+
+import requests
+from django.conf import settings
+
+
+def fetch_and_save_image(image_url):
+
+    external_image_url = image_url
+
+    local_image_name = image_url.split('/')[-1]
+
+    media_path = os.path.join(settings.MEDIA_URL, 'yugioh_card_images')
+
+    image_file_name = os.path.join(media_path, local_image_name)
+
+    headers = {"User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0",
+               "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+               "Accept-Language": "en-US,en;q=0.9"
+               }
+
+    if not os.path.exists(media_path):
+        os.makedirs(media_path)
+
+    if not os.path.exists(image_file_name):
+
+        image_response = requests.get(external_image_url, headers=headers, stream=True)
+
+        if image_response.status_code == 200:
+
+            with open(image_file_name, 'wb') as handler:
+                for chunk in image_response.iter_content(chunk_size=8192):
+                    handler.write(chunk)
+        else:
+
+            return external_image_url
+
+    return image_file_name

--- a/backend/yugioh/utils.py
+++ b/backend/yugioh/utils.py
@@ -2,6 +2,15 @@ import os
 
 import requests
 from django.conf import settings
+from django.utils.datetime_safe import datetime
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+
+class ImageFetchException(APIException):
+    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    default_detail = 'Service Unavailable. Unable to fetch the image.'
+    default_code = 'SERVICE_UNAVAILABLE'
 
 
 def fetch_and_save_image(image_url):
@@ -26,7 +35,7 @@ def fetch_and_save_image(image_url):
                 for chunk in image_response.iter_content(chunk_size=8192):
                     handler.write(chunk)
         else:
-
-            return None
+            timestamp = datetime.now().strftime('%d/%b/%Y %H:%M:%S')
+            raise ImageFetchException(f"[{timestamp}] Failed to download external image from {external_image_url}")
 
     return f"{settings.MEDIA_URL}yugioh_card_images/{local_image_name}"

--- a/backend/yugioh/utils.py
+++ b/backend/yugioh/utils.py
@@ -5,7 +5,6 @@ from django.conf import settings
 
 
 def fetch_and_save_image(image_url):
-
     external_image_url = image_url
 
     local_image_name = image_url.split('/')[-1]
@@ -14,17 +13,12 @@ def fetch_and_save_image(image_url):
 
     image_file_name = os.path.join(media_path, local_image_name)
 
-    headers = {"User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0",
-               "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-               "Accept-Language": "en-US,en;q=0.9"
-               }
-
     if not os.path.exists(media_path):
         os.makedirs(media_path)
 
     if not os.path.exists(image_file_name):
 
-        image_response = requests.get(external_image_url, headers=headers, stream=True)
+        image_response = requests.get(external_image_url, stream=True)
 
         if image_response.status_code == 200:
 

--- a/backend/yugioh/utils.py
+++ b/backend/yugioh/utils.py
@@ -33,6 +33,6 @@ def fetch_and_save_image(image_url):
                     handler.write(chunk)
         else:
 
-            return external_image_url
+            return None
 
     return f"{settings.MEDIA_URL}yugioh_card_images/{local_image_name}"

--- a/backend/yugioh/utils.py
+++ b/backend/yugioh/utils.py
@@ -10,7 +10,7 @@ def fetch_and_save_image(image_url):
 
     local_image_name = image_url.split('/')[-1]
 
-    media_path = os.path.join(settings.MEDIA_URL, 'yugioh_card_images')
+    media_path = os.path.join(settings.MEDIA_ROOT, 'yugioh_card_images')
 
     image_file_name = os.path.join(media_path, local_image_name)
 
@@ -35,4 +35,4 @@ def fetch_and_save_image(image_url):
 
             return external_image_url
 
-    return image_file_name
+    return f"{settings.MEDIA_URL}yugioh_card_images/{local_image_name}"


### PR DESCRIPTION
This PR fixes issue #65 

I have implemented a manage command which is similar to the seed command for downloading one, staple, or all card images.
This was for analytic purposes, but it's good to have it there, just in case.

The logic for saving the cards is simple and if it's not a good approach please let me know.
It has one util function for downloading and saving a card image in our local media folder. After that, a serializer Mixin returns the local URL for the requested image in every serializer where the card image is needed.
