### PR TITLE
Fix issues with the changelog

### DIFF
--- a/frontend/src/components/about/ChangelogList.tsx
+++ b/frontend/src/components/about/ChangelogList.tsx
@@ -23,9 +23,9 @@ function ChangelogList(props: ChangelogListProps): JSX.Element {
   }
 
   return (
-    <div className="mb-16">
-      <h3 className="font-bold text-left text-2xl mb-2">{props.heading}</h3>
-      <ul>
+    <div className="mb-16 lg:w-full w-[200px] mx-auto whitespace-nowrap">
+      <h3 className="font-bold text-2xl mb-2">{props.heading}</h3>
+      <ul className="inline-block">
         {props.items.map((item) => (
           <ChangelogListItem
             key={`changelog-list-item-${item}-${props.version}-${props.type}`}

--- a/frontend/src/constants/changelogArchive.ts
+++ b/frontend/src/constants/changelogArchive.ts
@@ -2,8 +2,9 @@
  * This array is used to render the changelog. For each new version release,
  * you should simply update the archive and the changelog page will also be updated.
  *
- * The versions are ordered by their release dates descending, meaning
- * that the newest version should be the first element.
+ * The versions are ordered by their release dates ascending, meaning
+ * that the newest version should be the last element
+ * (the changelog page handles the sorting itself).
  *
  * If a version is missing new features, fixes, or deprecations, you
  * should simply supply an empty array for the respective category.

--- a/frontend/src/constants/changelogArchive.ts
+++ b/frontend/src/constants/changelogArchive.ts
@@ -22,8 +22,8 @@ export const changelogArchive: readonly ChangelogArchive[] = Object.freeze([
   {
     version: '1.2.0',
     date: 'June 12, 2024',
-    features: ['Improved User Feedback', 'Improved Navigation', 'Show Image Previews'],
-    fixes: ['Best Sellers Fixes', 'Fixed Delisting Bugs'],
+    features: ['Improved user feedback', 'Improved navigation', 'Show image previews'],
+    fixes: ['Best sellers fixes', 'Fixed delisting bugs'],
     deprecated: [],
   },
 ]);

--- a/frontend/src/pages/about/Changelog.tsx
+++ b/frontend/src/pages/about/Changelog.tsx
@@ -5,6 +5,8 @@ import ChangelogList from '../../components/about/ChangelogList';
 import CardflowTabs from '../../components/sellListing/CardflowTabs';
 import { changelogArchive } from '../../constants/changelogArchive';
 
+const reversedChangelogArchive = [...changelogArchive].reverse();
+
 function Changelog(): JSX.Element {
   const breadcrumbNavigation: BreadcrumbLink[] = [
     {
@@ -18,7 +20,7 @@ function Changelog(): JSX.Element {
       <CardflowTabs />
       <BreadcrumbNavigation links={breadcrumbNavigation} heading="Changelog" />
       <PageSection className="mt-4 lg:px-12 py-4 lg:py-20 w-11/12 lg:w-4/5 mx-auto">
-        {changelogArchive.map((milestone, i) => (
+        {reversedChangelogArchive.map((milestone, i) => (
           <>
             <section
               className="flex items-center lg:items-start lg:w-3/5 flex-col lg:flex-row lg:justify-between"

--- a/frontend/src/pages/about/Changelog.tsx
+++ b/frontend/src/pages/about/Changelog.tsx
@@ -21,7 +21,7 @@ function Changelog(): JSX.Element {
       <BreadcrumbNavigation links={breadcrumbNavigation} heading="Changelog" />
       <PageSection className="mt-4 lg:px-12 py-4 lg:py-20 w-11/12 lg:w-4/5 mx-auto">
         {reversedChangelogArchive.map((milestone, i) => (
-          <>
+          <div key={milestone.version}>
             <section
               className="flex items-center lg:items-start lg:w-3/5 flex-col lg:flex-row lg:justify-between"
               key={milestone.version}
@@ -54,7 +54,7 @@ function Changelog(): JSX.Element {
               </div>
             </section>
             {i < changelogArchive.length - 1 ? <Divider sx={{ marginBottom: 4 }} /> : <></>}
-          </>
+          </div>
         ))}
       </PageSection>
     </section>

--- a/frontend/src/pages/about/Changelog.tsx
+++ b/frontend/src/pages/about/Changelog.tsx
@@ -22,10 +22,7 @@ function Changelog(): JSX.Element {
       <PageSection className="mt-4 lg:px-12 py-4 lg:py-20 w-11/12 lg:w-4/5 mx-auto">
         {reversedChangelogArchive.map((milestone, i) => (
           <div key={milestone.version}>
-            <section
-              className="flex items-center lg:items-start lg:w-3/5 flex-col lg:flex-row lg:justify-between"
-              key={milestone.version}
-            >
+            <section className="flex items-center lg:items-start lg:w-3/5 flex-col lg:flex-row lg:justify-between">
               <div>
                 <h2 className="text-3xl text-center lg:text-left lg:text-base font-bold">
                   v{milestone.version}

--- a/frontend/src/pages/about/Changelog.tsx
+++ b/frontend/src/pages/about/Changelog.tsx
@@ -22,14 +22,14 @@ function Changelog(): JSX.Element {
       <PageSection className="mt-4 lg:px-12 py-4 lg:py-20 w-11/12 lg:w-4/5 mx-auto">
         {reversedChangelogArchive.map((milestone, i) => (
           <div key={milestone.version}>
-            <section className="flex items-center lg:items-start lg:w-3/5 flex-col lg:flex-row lg:justify-between">
+            <section className="lg:flex block items-start flex-row justify-between">
               <div>
                 <h2 className="text-3xl text-center lg:text-left lg:text-base font-bold">
                   v{milestone.version}
                 </h2>
                 <div className="text-center mb-8 lg:text-left">{milestone.date}</div>
               </div>
-              <div>
+              <div className="lg:w-3/5">
                 <ChangelogList
                   version={milestone.version}
                   type="feature"


### PR DESCRIPTION
Closes #120 

Currently, you need to put the newest version as the first element in the array in order for it to be displayed at the top. Now this is reversed—the newest version is on the bottom and will be rendered first. I could maybe look into creating some sorting function to use the version or date, but I feel like it's a good idea to enforce some order in the array itself for readability.

In addition, I noticed that the bullets do not align consistently if they are of different widths, this PR also fixes this.

Finally, I noticed that React was complaining about a missing key, so I fixed that too

(also, something really minor, but I also made the casing in the 1.2 milestone consistent with the one in 1.0)