### PR TITLE
Disable "Not received" when ten days haven't passed on the front end

### DIFF
--- a/frontend/src/components/orders/OrdersTableRow.tsx
+++ b/frontend/src/components/orders/OrdersTableRow.tsx
@@ -16,6 +16,8 @@ function OrdersTableRow(props: OrdersTableRowProps): JSX.Element {
   const [open, setOpen] = useState(false);
   const { t } = useTranslation('account');
 
+  const today = new Date();
+
   const quantity = props.order.order_items.reduce((total, order) => total + order.quantity, 0);
   const totalPrice = props.order.order_items.reduce(
     (total, order) => total + order.quantity * order.listing.price,
@@ -80,6 +82,7 @@ function OrdersTableRow(props: OrdersTableRowProps): JSX.Element {
         order={props.order}
         status={props.order.status}
         feedback={feedback}
+        today={today}
       />
     </>
   );

--- a/frontend/src/components/orders/ordersModal/OrdersModal.spec.tsx
+++ b/frontend/src/components/orders/ordersModal/OrdersModal.spec.tsx
@@ -8,7 +8,7 @@ import { Feedback } from '../../../services/feedback/types';
 import { feedbackService } from '../../../services/feedback/feedback';
 import '../../../i18next';
 
-function generateMockOrder(status: orderState): Order {
+function generateMockOrder(status: orderState, date?: Date): Order {
   const mockOrder: Order = {
     order_id: 1,
     sender_user: {
@@ -24,7 +24,12 @@ function generateMockOrder(status: orderState): Order {
     order_items: [],
     status,
     delivery_address: 'Mountain View',
-    status_history: [],
+    status_history: [
+      {
+        status: 'ordered',
+        timestamp: date ? date.toDateString() : new Date('January 17, 2024').toDateString(),
+      },
+    ],
   };
 
   return mockOrder;
@@ -50,6 +55,7 @@ describe('OrdersModal component tests', () => {
           status={'ordered'}
           userPosition={'seller'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -66,6 +72,7 @@ describe('OrdersModal component tests', () => {
           status={'ordered'}
           userPosition={'buyer'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -82,6 +89,7 @@ describe('OrdersModal component tests', () => {
           status={'ordered'}
           userPosition={'seller'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -101,6 +109,7 @@ describe('OrdersModal component tests', () => {
           status={'sent'}
           userPosition={'buyer'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -120,6 +129,7 @@ describe('OrdersModal component tests', () => {
           status={'sent'}
           userPosition={'seller'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -158,6 +168,7 @@ describe('OrdersModal component tests', () => {
           status={'ordered'}
           userPosition={'seller'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -192,6 +203,7 @@ describe('OrdersModal component tests', () => {
           status={'sent'}
           userPosition={'buyer'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -226,6 +238,7 @@ describe('OrdersModal component tests', () => {
           status={'completed'}
           userPosition={'buyer'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -250,6 +263,7 @@ describe('OrdersModal component tests', () => {
           status={'completed'}
           userPosition={'buyer'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -269,6 +283,7 @@ describe('OrdersModal component tests', () => {
           status={'rejected'}
           userPosition={'buyer'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -288,6 +303,7 @@ describe('OrdersModal component tests', () => {
           status={'completed'}
           userPosition={'seller'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -304,6 +320,7 @@ describe('OrdersModal component tests', () => {
           status={'sent'}
           userPosition={'seller'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -323,6 +340,7 @@ describe('OrdersModal component tests', () => {
           status={'completed'}
           userPosition={'buyer'}
           feedback={generateMockFeedback()}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -339,6 +357,7 @@ describe('OrdersModal component tests', () => {
           status={'rejected'}
           userPosition={'buyer'}
           feedback={generateMockFeedback()}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -353,10 +372,11 @@ describe('OrdersModal component tests', () => {
         <OrdersModal
           open={true}
           onClose={() => {}}
-          order={generateMockOrder('completed')}
+          order={generateMockOrder('completed', new Date('January 5, 2024'))}
           status={'completed'}
           userPosition={'buyer'}
           feedback={generateMockFeedback()}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -374,10 +394,11 @@ describe('OrdersModal component tests', () => {
         <OrdersModal
           open={true}
           onClose={() => {}}
-          order={generateMockOrder('rejected')}
+          order={generateMockOrder('rejected', new Date('January 5, 2024'))}
           status={'rejected'}
           userPosition={'buyer'}
           feedback={generateMockFeedback()}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -399,6 +420,7 @@ describe('OrdersModal component tests', () => {
           status={'completed'}
           userPosition={'seller'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -420,6 +442,7 @@ describe('OrdersModal component tests', () => {
           status={'rejected'}
           userPosition={'seller'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -432,15 +455,16 @@ describe('OrdersModal component tests', () => {
       expect(disabledRadios).toHaveLength(2);
     });
 
-    it('Are disabled when the order is ordered for the buyer', async () => {
+    it('Are disabled when the order is ordered for the buyer and ten days have passed', async () => {
       render(
         <OrdersModal
           open={true}
           onClose={() => {}}
-          order={generateMockOrder('ordered')}
+          order={generateMockOrder('ordered', new Date('January 1, 2024'))}
           status={'ordered'}
           userPosition={'buyer'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -453,15 +477,16 @@ describe('OrdersModal component tests', () => {
       expect(disabledRadios).toHaveLength(2);
     });
 
-    it('Are enabled when the order is sent for the buyer', async () => {
+    it('Are enabled when the order is sent for the buyer and 10 days have passed', async () => {
       render(
         <OrdersModal
           open={true}
           onClose={() => {}}
-          order={generateMockOrder('sent')}
+          order={generateMockOrder('sent', new Date('January 5, 2024'))}
           status={'sent'}
           userPosition={'buyer'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -483,6 +508,7 @@ describe('OrdersModal component tests', () => {
           status={'ordered'}
           userPosition={'seller'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -504,6 +530,7 @@ describe('OrdersModal component tests', () => {
           status={'sent'}
           userPosition={'seller'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -514,6 +541,29 @@ describe('OrdersModal component tests', () => {
       const enabledRadios = Array.from(radioButtons).filter((r) => !r.disabled);
 
       expect(enabledRadios).toHaveLength(2);
+    });
+
+    it('Not received is disabled when 10 days have not passed and the order is sent', async () => {
+      render(
+        <OrdersModal
+          open={true}
+          onClose={() => {}}
+          order={generateMockOrder('sent')}
+          status={'sent'}
+          userPosition={'buyer'}
+          feedback={undefined}
+          today={new Date('January 16, 2024')}
+        />,
+      );
+
+      const radioButtons = document.querySelectorAll(
+        '[role="radiogroup"] input',
+      ) as NodeListOf<HTMLInputElement>;
+
+      const radios = Array.from(radioButtons);
+
+      expect(radios[1].disabled).toBe(true);
+      expect(radios[0].disabled).toBe(false);
     });
   });
 
@@ -531,6 +581,7 @@ describe('OrdersModal component tests', () => {
           status={'completed'}
           userPosition={'buyer'}
           feedback={generateMockFeedback()}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -547,6 +598,7 @@ describe('OrdersModal component tests', () => {
           status={'completed'}
           userPosition={'buyer'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -563,6 +615,7 @@ describe('OrdersModal component tests', () => {
           status={'completed'}
           userPosition={'seller'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -581,6 +634,7 @@ describe('OrdersModal component tests', () => {
           status={'completed'}
           userPosition={'buyer'}
           feedback={generateMockFeedback()}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -597,6 +651,7 @@ describe('OrdersModal component tests', () => {
           status={'completed'}
           userPosition={'buyer'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 
@@ -613,6 +668,7 @@ describe('OrdersModal component tests', () => {
           status={'completed'}
           userPosition={'seller'}
           feedback={undefined}
+          today={new Date('January 17, 2024')}
         />,
       );
 

--- a/frontend/src/components/orders/ordersModal/OrdersModal.tsx
+++ b/frontend/src/components/orders/ordersModal/OrdersModal.tsx
@@ -48,6 +48,7 @@ type OrdersModalProps = {
   status: orderState;
   userPosition: 'seller' | 'buyer';
   feedback: Feedback | undefined;
+  today: Date;
 };
 
 function OrdersModal(props: OrdersModalProps): JSX.Element {
@@ -56,6 +57,14 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
   const toast = useToast();
   const { t } = useTranslation('account');
   const { t: commonT } = useTranslation('common');
+
+  const orderDate = new Date(
+    props.order.status_history[props.order.status_history.length - 1].timestamp,
+  );
+
+  const timeDifference = props.today.getTime() - orderDate.getTime();
+
+  const tenDaysHavePassed = timeDifference / (1000 * 60 * 60 * 24) > 10;
 
   const totalPrice = props.order.order_items.reduce(
     (total, order) => total + order.quantity * order.listing.price,
@@ -167,7 +176,7 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
                   value="completed"
                 />
                 <FormControlLabel
-                  disabled={props.status !== 'sent'}
+                  disabled={props.status !== 'sent' || !tenDaysHavePassed}
                   control={<Radio color="info" />}
                   label={t('salesAndOrders.status.not_received')}
                   value="not_received"


### PR DESCRIPTION
Closes #129 

(^ assuming the backend counterpart is closed first)

If the date at which a particular table row has been rendered is not 10 days after the date in the last element of the order status history (since the last element contains the date at which the order was placed), the not received radio button for the associated modal is disabled. Few notes:

- the button is always disabled when the status is not "sent" (regardless of whether ten days have passed or not), let me know if this is supposed to be changed
- if the OrdersTableRow component experiences a rerender (e.g. due to a page or language change), "today" will be recalculated, which potentially enables the radio button. I have opted for this approach to create something of a pseudo-polling effect for the user.
- I have not done any manual tests as to whether the button is enabled after ten days have passed (due to what I hope are obvious limitations), but I have updated the tests (including a few failing ones) and all of them pass, so I assume the enabling will work just as expected.