### PR TITLE
Make conversions precise, fix shopping cart currency bug

### DIFF
--- a/backend/cart/models.py
+++ b/backend/cart/models.py
@@ -27,6 +27,8 @@ class ShoppingCartItem(models.Model):
 
     @property
     def total_price(self) -> float:
+        if self.cart.user.is_authenticated and self.cart.user.currency_preference == 'EUR':
+            return self.quantity * round(self.listing.price * 0.511292, 2)
         return self.quantity * self.listing.price
 
     def __str__(self):

--- a/backend/listing/serializers.py
+++ b/backend/listing/serializers.py
@@ -23,7 +23,7 @@ class ListingSerializer(serializers.ModelSerializer):
         if request:
             user = request.user
             if user.is_authenticated and user.currency_preference == 'EUR':
-                representation['price'] = round(instance.price * 0.51, 2)
+                representation['price'] = round(instance.price * 0.511292, 2)
         return representation
 
     def create(self, validated_data):
@@ -31,7 +31,7 @@ class ListingSerializer(serializers.ModelSerializer):
         if request:
             user = request.user
             if user.is_authenticated and user.currency_preference == 'EUR':
-                validated_data['price'] = round(validated_data['price'] * 1.96, 2)
+                validated_data['price'] = round(validated_data['price'] * 1.95583, 2)
         return super().create(validated_data)
 
     def update(self, instance, validated_data):
@@ -39,7 +39,7 @@ class ListingSerializer(serializers.ModelSerializer):
         if request:
             user = request.user
             if user.is_authenticated and user.currency_preference == 'EUR':
-                validated_data['price'] = round(validated_data['price'] * 1.96, 2)
+                validated_data['price'] = round(validated_data['price'] * 1.95583, 2)
         return super().update(instance, validated_data)
 
 

--- a/backend/yugioh/serializers.py
+++ b/backend/yugioh/serializers.py
@@ -153,6 +153,6 @@ class BestSellerCardSerializer(serializers.ModelSerializer, CacheImageMixin):
             user = request.user
 
             if user.is_authenticated and getattr(user, 'currency_preference', 'BGN') == 'EUR':
-                lowest_price = round(lowest_price * 0.51, 2)
+                lowest_price = round(lowest_price * 0.511292, 2)
 
         return lowest_price

--- a/frontend/src/components/shoppingCart/ShoppingCartCheckout.tsx
+++ b/frontend/src/components/shoppingCart/ShoppingCartCheckout.tsx
@@ -46,11 +46,11 @@ function ShoppingCartCheckout(props: ShoppingCartCheckoutProps) {
         </Button>
         <Divider flexItem />
         <ul>
-          <CheckoutData
+          {/* <CheckoutData
             withDollar
             summary={t('cart.checkout.shippingCost')}
             data={props.shipmentCost}
-          />
+          /> */}
           <CheckoutData withDollar summary={t('cart.checkout.itemsCost')} data={props.totalPrice} />
         </ul>
         <Divider />

--- a/frontend/src/components/shoppingCart/ShoppingCartSummary.tsx
+++ b/frontend/src/components/shoppingCart/ShoppingCartSummary.tsx
@@ -58,10 +58,10 @@ function ShoppingCartSummary(props: ShoppingCartSummaryProps): JSX.Element {
               })}
               data={props.totalPrice}
             />
-            <SummaryData
+            {/* <SummaryData
               summary={commonT('purchaseDetails.shipmentPrice')}
               data={props.shipmentCost}
-            />
+            /> */}
             <SummaryData
               boldedData
               summary={commonT('purchaseDetails.totalPrice')}

--- a/frontend/src/translations/bg/buy.json
+++ b/frontend/src/translations/bg/buy.json
@@ -1,6 +1,6 @@
 {
   "bestSellers": {
-    "title": "Най-продавани карти за всички времена"
+    "title": "Най-продаваните карти"
   },
   "cardDetails": {
     "dataTable": {


### PR DESCRIPTION
Closes #140 
Closes #139

@RyotaMitaraiWeb I decided that it'd be easier to just make the conversions more precise, instead of reworking the way we save the prices. etc. We may definitely consider this in the future, but for now, I just want to get the product out for public beta testing with fewer bugs.
