### PR TITLE
Replace new listing search with an autocomplete

### DIFF
--- a/frontend/src/components/sellListing/NewSellListingBody.tsx
+++ b/frontend/src/components/sellListing/NewSellListingBody.tsx
@@ -4,7 +4,7 @@ import { YugiohCardInSet } from '../../services/yugioh/types';
 import { useDebounce } from '../../util/useDebounce';
 import { yugiohService } from '../../services/yugioh/yugiohService';
 import { useToast } from '../../util/useToast';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import CameraAltIcon from '@mui/icons-material/CameraAlt';
 
 type SearchResults = {
@@ -61,13 +61,12 @@ const NewListingBody: React.FC = () => {
               <TextField key={params.id} onChange={handleChange} {...params} />
             )}
             options={searchResults}
-            renderOption={(props, option) => {
-              const newProps = {
-                ...props,
-                key: option.id + option.name + option.rarity + 'new-listing',
-              };
-              return (
-                <MenuItem {...newProps} className="flex gap-6 w-full">
+            renderOption={(props, option) => (
+              <Link
+                to={`/sell/new/${option.id}`}
+                key={option.id + option.name + option.rarity + 'new-listing'}
+              >
+                <MenuItem {...props} className="flex gap-6 w-full">
                   <Tooltip title={<TooltipImage imageUrl={option.image} />} placement="left-start">
                     <ListItemIcon sx={{ color: 'black' }}>
                       <CameraAltIcon />
@@ -76,8 +75,8 @@ const NewListingBody: React.FC = () => {
                   <span>{option.setCode}</span>
                   <span>{option.name}</span>
                 </MenuItem>
-              );
-            }}
+              </Link>
+            )}
           />
         </div>
       </div>

--- a/frontend/src/components/sellListing/NewSellListingBody.tsx
+++ b/frontend/src/components/sellListing/NewSellListingBody.tsx
@@ -1,17 +1,96 @@
-import React from 'react';
-import SearchField from '../searchField/SearchField';
+import React, { useMemo, useState } from 'react';
+import { Autocomplete, ListItemIcon, MenuItem, TextField, Tooltip } from '@mui/material';
+import { YugiohCardInSet } from '../../services/yugioh/types';
+import { useDebounce } from '../../util/useDebounce';
+import { yugiohService } from '../../services/yugioh/yugiohService';
+import { useToast } from '../../util/useToast';
+import { useNavigate } from 'react-router-dom';
+import CameraAltIcon from '@mui/icons-material/CameraAlt';
+
+type SearchResults = {
+  id: number;
+  label: string;
+  setCode: string;
+  name: string;
+  image: string;
+  rarity: string;
+};
 
 const NewListingBody: React.FC = () => {
+  const [results, setResults] = useState<YugiohCardInSet[]>([]);
+  const navigate = useNavigate();
+
+  const searchResults = useMemo<SearchResults[]>(
+    () =>
+      results.map((r) => ({
+        id: r.id,
+        label: `${r.set.set_code} ${r.yugioh_card.card_name}`,
+        setCode: r.set.set_code,
+        name: r.yugioh_card.card_name,
+        image: r.yugioh_card.image,
+        rarity: r.rarity.rarity_code,
+      })),
+    [results],
+  );
+  const { error } = useToast();
+
+  const handleChange = useDebounce((event: React.ChangeEvent<HTMLInputElement>) => {
+    yugiohService
+      .searchCardsByName(event.target.value)
+      .then((data) => setResults(data.results))
+      .catch((err) => error({ error: err }));
+  }, 500);
+
+  function handleSelect(_event: any, option: string | SearchResults | null) {
+    if (option && typeof option !== 'string') {
+      navigate(`/sell/new/${option.id}`);
+    }
+  }
+
   return (
     <div className="bg-[#F5F5F5] min-h-screen pt-8">
       <div className="bg-white w-11/12 lg:w-5/6 lg:gap-0 gap-4 mx-auto p-8 flex flex-col lg:flex-row items-center border">
         <div className="w-1/2 lg:w-1/4 pb-[50%] lg:pb-[30%] bg-neutral-50 border border-stone-500"></div>
-        <div className="md:self-start lg:ml-12 mx-auto">
-          <SearchField isListing={true} />
+        <div className="md:self-start lg:ml-12 mx-auto w-full md:w-[400px]">
+          <Autocomplete
+            freeSolo
+            handleHomeEndKeys
+            selectOnFocus
+            onChange={handleSelect}
+            renderInput={(params) => (
+              <TextField key={params.id} onChange={handleChange} {...params} />
+            )}
+            options={searchResults}
+            renderOption={(props, option) => {
+              const newProps = {
+                ...props,
+                key: option.id + option.name + option.rarity + 'new-listing',
+              };
+              return (
+                <MenuItem {...newProps} className="flex gap-6 w-full">
+                  <Tooltip title={<TooltipImage imageUrl={option.image} />} placement="left-start">
+                    <ListItemIcon sx={{ color: 'black' }}>
+                      <CameraAltIcon />
+                    </ListItemIcon>
+                  </Tooltip>
+                  <span>{option.setCode}</span>
+                  <span>{option.name}</span>
+                </MenuItem>
+              );
+            }}
+          />
         </div>
       </div>
     </div>
   );
 };
+
+type TooltipImageProps = {
+  imageUrl: string;
+};
+
+function TooltipImage(props: TooltipImageProps) {
+  return <img src={props.imageUrl} className="w-64" alt="" />;
+}
 
 export default NewListingBody;

--- a/frontend/src/components/sellListing/NewSellListingBody.tsx
+++ b/frontend/src/components/sellListing/NewSellListingBody.tsx
@@ -72,8 +72,10 @@ const NewListingBody: React.FC = () => {
                       <CameraAltIcon />
                     </ListItemIcon>
                   </Tooltip>
-                  <span>{option.setCode}</span>
-                  <span>{option.name}</span>
+                  <div className="flex items-center text-sm md:text-base">
+                    <div className="w-20">{option.setCode}</div>
+                    <div>{option.name}</div>
+                  </div>
                 </MenuItem>
               </Link>
             )}


### PR DESCRIPTION
Closes #141 

The new listing page now has an autocomplete. Once the user types in something, a debounced request (debounced by a half a second) will make a search request and populate the menu options below it. Clicking any of those will redirect you to the create page for the respective card

Notes:
- although the options are rendered as hyperlinks, there is still a function that triggers when an option is selected that performs a programmatic navigation. The reason for that is to support keyboard navigation as well (as you can cycle through the options with arrow keys and the Home and End keys, as well as select an option with Enter), in which case hyperlinks aren't enough. This also has the benefit of things like URL preview (at the bottom of most browsers) and ability to open the page in a new tab.
- Because the search endpoint is paginated, the list will never display more than ten items. This is something that should probably be fixed before we release a stable version.
- Cards with particularly long names will require horizontal scrolling. The only (reasonably achievable) way to fix this is to make the search field wider.