### PR TITLE
Adjust order modal sequence and split off some of  the layout

### DIFF
--- a/frontend/src/components/orders/ordersModal/OrdersModal.tsx
+++ b/frontend/src/components/orders/ordersModal/OrdersModal.tsx
@@ -259,7 +259,7 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
           </section>
           <Divider className="hidden lg:block place-self-center" orientation="vertical" flexItem />
           <Divider className="block lg:hidden" flexItem />
-          <section className="flex flex-col mx-auto">
+          <section className="flex flex-col">
             <h3 className="font-bold mb-4 lg:mb-2 text-center lg:text-left">
               {t('salesAndOrders.modal.feedback.title')}
             </h3>

--- a/frontend/src/components/orders/ordersModal/OrdersModal.tsx
+++ b/frontend/src/components/orders/ordersModal/OrdersModal.tsx
@@ -244,7 +244,8 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
               className="lg:w-full"
             />
           </div>
-          <section className="my-4 lg:my-0">
+          <Divider className="block lg:hidden" flexItem />
+          <section className="lg:my-0">
             <h3 className="font-bold mb-2 lg:mb-4 text-center lg:text-left">
               {t('salesAndOrders.modal.history.title')}
             </h3>

--- a/frontend/src/components/orders/ordersModal/OrdersModal.tsx
+++ b/frontend/src/components/orders/ordersModal/OrdersModal.tsx
@@ -4,7 +4,6 @@ import {
   FormControl,
   FormControlLabel,
   InputAdornment,
-  Link,
   Radio,
   RadioGroup,
   Rating as BaseRating,
@@ -25,6 +24,7 @@ import { useToast } from '../../../util/useToast';
 import { useTranslation } from 'react-i18next';
 import OrdersModalHeader from './layout/OrdersModalHeader';
 import OrdersModalPurchases from './layout/OrderModalPurchases';
+import OrdersModalUsernameLink from './layout/OrdersModalUsernameLink';
 
 const Rating = styled(BaseRating)({
   '& .MuiRating-iconFilled': {
@@ -82,9 +82,6 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
       props.status !== 'rejected' &&
       props.status !== 'not_sent' &&
       props.status !== 'not_received');
-
-  const userToDisplay =
-    props.userPosition === 'seller' ? props.order.receiver_user : props.order.sender_user;
 
   const [rating, setRating] = useState(props.feedback?.rating || 0);
   const saveButtonIsDisabled =
@@ -207,16 +204,7 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
         </div>
         <Divider />
         <OrdersModalPurchases order={order} />
-        <div className="lg:text-left text-center">
-          <Link
-            href={`/user/${userToDisplay.username}`}
-            sx={{ color: '#0B70E5', fontSize: 20 }}
-            underline="hover"
-            className="font-bold"
-          >
-            {userToDisplay.username}
-          </Link>
-        </div>
+        <OrdersModalUsernameLink order={order} userPosition={props.userPosition} />
         <div className="grid grid-cols-[2fr,1fr,3fr] gap-y-16">
           <section>
             <h3 className="font-bold mb-4">{commonT('purchaseDetails.summary')}</h3>

--- a/frontend/src/components/orders/ordersModal/OrdersModal.tsx
+++ b/frontend/src/components/orders/ordersModal/OrdersModal.tsx
@@ -208,7 +208,7 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
         <div className="grid grid-cols-[2fr,1fr,3fr] gap-y-16">
           <section>
             <h3 className="font-bold mb-4">{commonT('purchaseDetails.summary')}</h3>
-            <ul className="mr-4">
+            <ul>
               <SummaryData
                 summary={commonT('purchaseDetails.cardsTotalPrice', {
                   count: props.order.order_items.reduce((total, o) => total + o.quantity, 0),
@@ -258,7 +258,7 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
           </section>
           <Divider className="hidden lg:block place-self-center" orientation="vertical" flexItem />
           <Divider className="block lg:hidden" flexItem />
-          <section className="w-full flex flex-col items-center lg:block lg:mx-auto">
+          <section className="flex flex-col mx-auto">
             <h3 className="font-bold mb-4 lg:mb-2 text-center lg:text-left">
               {t('salesAndOrders.modal.feedback.title')}
             </h3>

--- a/frontend/src/components/orders/ordersModal/OrdersModal.tsx
+++ b/frontend/src/components/orders/ordersModal/OrdersModal.tsx
@@ -217,8 +217,8 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
             {userToDisplay.username}
           </Link>
         </div>
-        <div className="flex flex-col items-center lg:items-start text-center lg:text-left lg:flex-row gap-4 py-4">
-          <section className="w-2/5">
+        <div className="grid grid-cols-[2fr,1fr,3fr] gap-y-16">
+          <section>
             <h3 className="font-bold mb-4">{commonT('purchaseDetails.summary')}</h3>
             <ul className="mr-4">
               <SummaryData
@@ -238,9 +238,9 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
               />
             </ul>
           </section>
-          <Divider className="hidden lg:block" orientation="vertical" flexItem />
+          <Divider className="hidden lg:block place-self-center" orientation="vertical" flexItem />
           <Divider className="block lg:hidden" flexItem />
-          <div>
+          <div className="">
             <h3 className="font-bold mb-4">{commonT('purchaseDetails.shippingDetails.title')}</h3>
             <TextField
               size="small"
@@ -256,8 +256,6 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
               className="w-full"
             />
           </div>
-        </div>
-        <div className="flex flex-col items-center gap-4 lg:gap-0 lg:items-start lg:flex-row w-full">
           <section>
             <h3 className="font-bold mb-2 lg:mb-4 text-center lg:text-left">
               {t('salesAndOrders.modal.history.title')}
@@ -270,9 +268,9 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
               ))}
             </ul>
           </section>
-          <Divider className="hidden lg:block" orientation="vertical" flexItem />
+          <Divider className="hidden lg:block place-self-center" orientation="vertical" flexItem />
           <Divider className="block lg:hidden" flexItem />
-          <section className="w-full flex flex-col items-center lg:w-auto lg:block lg:mx-auto">
+          <section className="w-full flex flex-col items-center lg:block lg:mx-auto">
             <h3 className="font-bold mb-4 lg:mb-2 text-center lg:text-left">
               {t('salesAndOrders.modal.feedback.title')}
             </h3>

--- a/frontend/src/components/orders/ordersModal/OrdersModal.tsx
+++ b/frontend/src/components/orders/ordersModal/OrdersModal.tsx
@@ -205,7 +205,7 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
         <Divider />
         <OrdersModalPurchases order={order} />
         <OrdersModalUsernameLink order={order} userPosition={props.userPosition} />
-        <div className="grid grid-cols-[2fr,1fr,3fr] gap-y-16">
+        <div className="grid grid-cols-[2fr,0.5fr,3fr] gap-y-16">
           <section>
             <h3 className="font-bold mb-4">{commonT('purchaseDetails.summary')}</h3>
             <ul>

--- a/frontend/src/components/orders/ordersModal/OrdersModal.tsx
+++ b/frontend/src/components/orders/ordersModal/OrdersModal.tsx
@@ -205,8 +205,8 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
         <Divider />
         <OrdersModalPurchases order={order} />
         <OrdersModalUsernameLink order={order} userPosition={props.userPosition} />
-        <div className="grid grid-cols-[2fr,0.5fr,3fr] gap-y-16">
-          <section>
+        <div className="flex flex-col text-center gap-y-4 lg:text-left lg:grid lg:grid-cols-[2fr,0.5fr,3fr] lg:gap-y-16">
+          <section className="w-3/5 mx-auto lg:w-full">
             <h3 className="font-bold mb-4">{commonT('purchaseDetails.summary')}</h3>
             <ul>
               <SummaryData
@@ -241,14 +241,14 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
               }}
               value={order.delivery_address}
               disabled={true}
-              className="w-full"
+              className="lg:w-full"
             />
           </div>
-          <section>
+          <section className="my-4 lg:my-0">
             <h3 className="font-bold mb-2 lg:mb-4 text-center lg:text-left">
               {t('salesAndOrders.modal.history.title')}
             </h3>
-            <ul className="flex flex-col gap-2">
+            <ul className="flex flex-col gap-4 lg:gap-2">
               {props.order.status_history.map((s) => (
                 <li key={s.timestamp + s.status}>
                   {t('salesAndOrders.status.' + s.status)} - {formatTimestamp(s.timestamp)}
@@ -262,7 +262,7 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
             <h3 className="font-bold mb-4 lg:mb-2 text-center lg:text-left">
               {t('salesAndOrders.modal.feedback.title')}
             </h3>
-            <form className="flex flex-col w-full items-center lg:w-auto lg:items-start">
+            <form className="flex flex-col w-full items-center gap-y-4 lg:gap-y-0 lg:w-auto lg:items-start">
               <label
                 id="rating"
                 data-disabled={cannotGiveFeedback}

--- a/frontend/src/components/orders/ordersModal/OrdersModal.tsx
+++ b/frontend/src/components/orders/ordersModal/OrdersModal.tsx
@@ -13,9 +13,7 @@ import {
   Button,
 } from '@mui/material';
 import { Order, orderState } from '../../../services/orders/types';
-import OrderStatusBadge from '../OrderStatusBadge';
 import { useEffect, useState } from 'react';
-import MarketTable from '../../marketTable/MarketTable';
 import SummaryData from '../../shoppingCart/SummaryData';
 import Home from '@mui/icons-material/Home';
 import { createPortal } from 'react-dom';
@@ -25,6 +23,8 @@ import { Feedback } from '../../../services/feedback/types';
 import { feedbackService } from '../../../services/feedback/feedback';
 import { useToast } from '../../../util/useToast';
 import { useTranslation } from 'react-i18next';
+import OrdersModalHeader from './layout/OrdersModalHeader';
+import OrdersModalPurchases from './layout/OrderModalPurchases';
 
 const Rating = styled(BaseRating)({
   '& .MuiRating-iconFilled': {
@@ -159,17 +159,7 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
       maxWidth="md"
     >
       <div className="p-16">
-        <section className="flex items-center mb-6 justify-between">
-          <div className="flex items-center gap-4 justify-center lg:justify-start">
-            <h2 className="font-bold text-4xl">
-              {t('salesAndOrders.modal.title')} #{order.order_id}
-            </h2>
-            <OrderStatusBadge orderState={order.status} />
-          </div>
-          <Link href="/about/faq" className="!text-gray-500" target="_blank">
-            {t('salesAndOrders.modal.supportButtonText')}
-          </Link>
-        </section>
+        <OrdersModalHeader order={order} />
         <div className="mb-4 justify-center flex lg:block">
           <FormControl>
             {props.userPosition === 'buyer' ? (
@@ -216,27 +206,7 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
           </FormControl>
         </div>
         <Divider />
-        <div className="flex mt-4 mb-8 lg:justify-center w-full overflow-auto">
-          <MarketTable className="text-center w-full">
-            <thead>
-              <tr>
-                <th colSpan={2}>{commonT('purchaseDetails.table.tableHeaders.cardDetails')}</th>
-                <th>{commonT('purchaseDetails.table.tableHeaders.quantity')}</th>
-                <th>{commonT('purchaseDetails.table.tableHeaders.price')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {order.order_items.map((o) => (
-                <tr key={o.listing.id}>
-                  <td className="font-bold">{o.listing.card_name}</td>
-                  <td>{o.listing.card_in_set.set.set_code}</td>
-                  <td>{o.quantity}</td>
-                  <td className="font-bold">$&nbsp;{o.listing.price * o.quantity}</td>
-                </tr>
-              ))}
-            </tbody>
-          </MarketTable>
-        </div>
+        <OrdersModalPurchases order={order} />
         <div className="lg:text-left text-center">
           <Link
             href={`/user/${userToDisplay.username}`}

--- a/frontend/src/components/orders/ordersModal/OrdersModal.tsx
+++ b/frontend/src/components/orders/ordersModal/OrdersModal.tsx
@@ -215,6 +215,28 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
             )}
           </FormControl>
         </div>
+        <Divider />
+        <div className="flex mt-4 mb-8 lg:justify-center w-full overflow-auto">
+          <MarketTable className="text-center w-full">
+            <thead>
+              <tr>
+                <th colSpan={2}>{commonT('purchaseDetails.table.tableHeaders.cardDetails')}</th>
+                <th>{commonT('purchaseDetails.table.tableHeaders.quantity')}</th>
+                <th>{commonT('purchaseDetails.table.tableHeaders.price')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {order.order_items.map((o) => (
+                <tr key={o.listing.id}>
+                  <td className="font-bold">{o.listing.card_name}</td>
+                  <td>{o.listing.card_in_set.set.set_code}</td>
+                  <td>{o.quantity}</td>
+                  <td className="font-bold">$&nbsp;{o.listing.price * o.quantity}</td>
+                </tr>
+              ))}
+            </tbody>
+          </MarketTable>
+        </div>
         <div className="lg:text-left text-center">
           <Link
             href={`/user/${userToDisplay.username}`}
@@ -225,7 +247,6 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
             {userToDisplay.username}
           </Link>
         </div>
-        <Divider />
         <div className="flex flex-col items-center lg:items-start text-center lg:text-left lg:flex-row gap-4 py-4">
           <section className="w-2/5">
             <h3 className="font-bold mb-4">{commonT('purchaseDetails.summary')}</h3>
@@ -266,27 +287,6 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
             />
           </div>
         </div>
-        <div className="flex mt-4 mb-8 lg:justify-center w-full overflow-auto">
-          <MarketTable className="text-center w-full">
-            <thead>
-              <tr>
-                <th colSpan={2}>{commonT('purchaseDetails.table.tableHeaders.cardDetails')}</th>
-                <th>{commonT('purchaseDetails.table.tableHeaders.quantity')}</th>
-                <th>{commonT('purchaseDetails.table.tableHeaders.price')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {order.order_items.map((o) => (
-                <tr key={o.listing.id}>
-                  <td className="font-bold">{o.listing.card_name}</td>
-                  <td>{o.listing.card_in_set.set.set_code}</td>
-                  <td>{o.quantity}</td>
-                  <td className="font-bold">$&nbsp;{o.listing.price * o.quantity}</td>
-                </tr>
-              ))}
-            </tbody>
-          </MarketTable>
-        </div>
         <div className="flex flex-col items-center gap-4 lg:gap-0 lg:items-start lg:flex-row w-full">
           <section>
             <h3 className="font-bold mb-2 lg:mb-4 text-center lg:text-left">
@@ -300,7 +300,7 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
               ))}
             </ul>
           </section>
-          <Divider className="hidden lg:block lg:px-[81px]" orientation="vertical" flexItem />
+          <Divider className="hidden lg:block" orientation="vertical" flexItem />
           <Divider className="block lg:hidden" flexItem />
           <section className="w-full flex flex-col items-center lg:w-auto lg:block lg:mx-auto">
             <h3 className="font-bold mb-4 lg:mb-2 text-center lg:text-left">

--- a/frontend/src/components/orders/ordersModal/OrdersModal.tsx
+++ b/frontend/src/components/orders/ordersModal/OrdersModal.tsx
@@ -228,7 +228,7 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
           </section>
           <Divider className="hidden lg:block place-self-center" orientation="vertical" flexItem />
           <Divider className="block lg:hidden" flexItem />
-          <div className="">
+          <div>
             <h3 className="font-bold mb-4">{commonT('purchaseDetails.shippingDetails.title')}</h3>
             <TextField
               size="small"
@@ -268,7 +268,7 @@ function OrdersModal(props: OrdersModalProps): JSX.Element {
                 data-disabled={cannotGiveFeedback}
                 className="flex items-center gap-2 mb-2"
               >
-                <span>{t('salesAndOrders.modal.feedback.rate')}</span>{' '}
+                <span>{t('salesAndOrders.modal.feedback.rate')}</span>
                 <Rating
                   onChange={changeRating}
                   disabled={cannotGiveFeedback}

--- a/frontend/src/components/orders/ordersModal/layout/OrderModalPurchases.tsx
+++ b/frontend/src/components/orders/ordersModal/layout/OrderModalPurchases.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { Order } from '../../../../services/orders/types';
 import MarketTable from '../../../marketTable/MarketTable';
+import { useCurrentUser } from '../../../../context/user';
 
 type OrderModalPurchasesProps = {
   order: Order;
@@ -8,6 +9,7 @@ type OrderModalPurchasesProps = {
 
 function OrdersModalPurchases(props: OrderModalPurchasesProps): JSX.Element {
   const { t } = useTranslation('common');
+  const { user } = useCurrentUser();
 
   return (
     <div className="flex mt-4 mb-8 lg:justify-center w-full overflow-auto">
@@ -25,7 +27,9 @@ function OrdersModalPurchases(props: OrderModalPurchasesProps): JSX.Element {
               <td className="font-bold">{o.listing.card_name}</td>
               <td>{o.listing.card_in_set.set.set_code}</td>
               <td>{o.quantity}</td>
-              <td className="font-bold">$&nbsp;{o.listing.price * o.quantity}</td>
+              <td className="font-bold">
+                {o.listing.price * o.quantity} {user.currency_preference}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/components/orders/ordersModal/layout/OrderModalPurchases.tsx
+++ b/frontend/src/components/orders/ordersModal/layout/OrderModalPurchases.tsx
@@ -1,0 +1,37 @@
+import { useTranslation } from 'react-i18next';
+import { Order } from '../../../../services/orders/types';
+import MarketTable from '../../../marketTable/MarketTable';
+
+type OrderModalPurchasesProps = {
+  order: Order;
+};
+
+function OrdersModalPurchases(props: OrderModalPurchasesProps): JSX.Element {
+  const { t } = useTranslation('common');
+
+  return (
+    <div className="flex mt-4 mb-8 lg:justify-center w-full overflow-auto">
+      <MarketTable className="text-center w-full">
+        <thead>
+          <tr>
+            <th colSpan={2}>{t('purchaseDetails.table.tableHeaders.cardDetails')}</th>
+            <th>{t('purchaseDetails.table.tableHeaders.quantity')}</th>
+            <th>{t('purchaseDetails.table.tableHeaders.price')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {props.order.order_items.map((o) => (
+            <tr key={o.listing.id}>
+              <td className="font-bold">{o.listing.card_name}</td>
+              <td>{o.listing.card_in_set.set.set_code}</td>
+              <td>{o.quantity}</td>
+              <td className="font-bold">$&nbsp;{o.listing.price * o.quantity}</td>
+            </tr>
+          ))}
+        </tbody>
+      </MarketTable>
+    </div>
+  );
+}
+
+export default OrdersModalPurchases;

--- a/frontend/src/components/orders/ordersModal/layout/OrdersModalHeader.tsx
+++ b/frontend/src/components/orders/ordersModal/layout/OrdersModalHeader.tsx
@@ -1,0 +1,28 @@
+import { Link } from '@mui/material';
+import { Order } from '../../../../services/orders/types';
+import OrderStatusBadge from '../../OrderStatusBadge';
+import { useTranslation } from 'react-i18next';
+
+type OrdersModalHeaderProps = {
+  order: Order;
+};
+
+function OrdersModalHeader(props: OrdersModalHeaderProps): JSX.Element {
+  const { t } = useTranslation('account');
+
+  return (
+    <section className="flex items-center mb-6 justify-between">
+      <div className="flex items-center gap-4 justify-center lg:justify-start">
+        <h2 className="font-bold text-4xl">
+          {t('salesAndOrders.modal.title')} #{props.order.order_id}
+        </h2>
+        <OrderStatusBadge orderState={props.order.status} />
+      </div>
+      <Link href="/about/faq" className="!text-gray-500" target="_blank">
+        {t('salesAndOrders.modal.supportButtonText')}
+      </Link>
+    </section>
+  );
+}
+
+export default OrdersModalHeader;

--- a/frontend/src/components/orders/ordersModal/layout/OrdersModalUsernameLink.tsx
+++ b/frontend/src/components/orders/ordersModal/layout/OrdersModalUsernameLink.tsx
@@ -1,0 +1,26 @@
+import { Link } from '@mui/material';
+import { Order } from '../../../../services/orders/types';
+
+type OrdersModalUsernameLinkProps = {
+  userPosition: 'seller' | 'buyer';
+  order: Order;
+};
+
+function OrdersModalUsernameLink(props: OrdersModalUsernameLinkProps): JSX.Element {
+  const userToDisplay =
+    props.userPosition === 'seller' ? props.order.receiver_user : props.order.sender_user;
+  return (
+    <div className="lg:text-left text-center mb-4">
+      <Link
+        href={`/user/${userToDisplay.username}`}
+        sx={{ color: '#0B70E5', fontSize: 20 }}
+        underline="hover"
+        className="font-bold"
+      >
+        {userToDisplay.username}
+      </Link>
+    </div>
+  );
+}
+
+export default OrdersModalUsernameLink;

--- a/frontend/src/translations/bg/account.json
+++ b/frontend/src/translations/bg/account.json
@@ -85,8 +85,8 @@
       },
       "feedback": {
         "title": "Обратна връзка",
-        "rate": "Оценка",
-        "comment": "Коментар"
+        "rate": "Оценка:",
+        "comment": "Коментар:"
       },
       "reportButtonText": "Докладвай за нередност",
       "cancelButtonText": "Затвори",


### PR DESCRIPTION
Closes #132 

This PR does three things:
- changes the order of the layout
- makes the separators on the desktop layout correctly aligned
- separates some of the elements in their own components. This was done to make it easier for me to finish this.

I have kept the previous UI mostly intact (e.g. the feedback section is still centered in the middle of its own part), though there may be some minor changes here and there