### PR TITLE
Issue #148

### DIFF
--- a/frontend/src/translations/en/common.json
+++ b/frontend/src/translations/en/common.json
@@ -35,7 +35,7 @@
     "signUp": "Sign up"
   },
   "search": {
-    "placeholder": "Type \"/\" to search",
+    "placeholder": "Search",
     "search": "Search",
     "showAll": "Show all {{results}} results.",
     "openSearchToolTip": "Search cards by name"


### PR DESCRIPTION
This fix addresses #148.

Changes the placeholder text in search bars from "Type / to search" to "Search"