### PR TITLE
Implement trade checkbox on the frontend

### DIFF
--- a/frontend/src/components/sellListing/ListingForm.tsx
+++ b/frontend/src/components/sellListing/ListingForm.tsx
@@ -87,6 +87,7 @@ function ListingForm(props: ListingFormProps) {
           rarity_code: '',
         },
       },
+      is_trade_considered: false,
     },
   );
 
@@ -151,6 +152,7 @@ function ListingForm(props: ListingFormProps) {
       is_sold: false,
       is_listed: formData.is_listed,
       card: props.cardInSet.id,
+      is_trade_considered: formData.is_trade_considered,
     };
 
     props.onSubmit(newData, postAnother);

--- a/frontend/src/components/sellListing/ListingForm.tsx
+++ b/frontend/src/components/sellListing/ListingForm.tsx
@@ -1,4 +1,14 @@
-import { SelectChangeEvent, TextField, Select, MenuItem, Chip, Divider, Link } from '@mui/material';
+import {
+  SelectChangeEvent,
+  TextField,
+  Select,
+  MenuItem,
+  Chip,
+  Divider,
+  Link,
+  FormControlLabel,
+  Checkbox,
+} from '@mui/material';
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
@@ -212,68 +222,79 @@ function ListingForm(props: ListingFormProps) {
                   label={props.cardInSet.rarity.rarity_code}
                 />
               </div>
-              <div className="flex flex-col mt-10 lg:mt-20 gap-4">
-                <div className="flex flex-col lg:flex-row gap-4">
-                  <TextField
-                    type="number"
-                    name="quantity"
-                    value={formData.quantity}
-                    onChange={handleQuantityChange}
-                    placeholder={t('newListing.secondSection.quantity')}
-                    className="w-36"
-                    size="small"
-                    label={t('newListing.secondSection.quantity')}
-                    InputProps={{
-                      startAdornment: <TagIcon className="mr-2" />,
-                    }}
-                  />
-                  <Select
-                    id="condition"
-                    name="condition"
-                    size="small"
-                    placeholder="Condition"
-                    value={formData.condition}
-                    onChange={handleConditionChange}
-                    className="w-36"
-                    renderValue={(value) => (
-                      <>
-                        <DiamondIcon className="mr-2" />
-                        <span>{commonT(`conditions.${value}`)}</span>
-                      </>
-                    )}
-                  >
-                    <MenuItem disabled>
-                      <i>{t('newListing.secondSection.condition')}</i>
-                    </MenuItem>
-                    <MenuItem value="poor">{commonT('conditions.poor')}</MenuItem>
-                    <MenuItem value="played">{commonT('conditions.played')}</MenuItem>
-                    <MenuItem value="good">{commonT('conditions.good')}</MenuItem>
-                    <MenuItem value="excellent">{commonT('conditions.excellent')}</MenuItem>
-                  </Select>
-                </div>
-                <div>
-                  <div className="w-36">
+              <div className="flex flex-col lg:flex-row gap-4 lg:items-center">
+                <div className="flex flex-col mt-10 lg:mt-20 gap-4">
+                  <div className="flex flex-col lg:flex-row gap-4">
                     <TextField
                       type="number"
-                      name="price"
-                      value={formData.price}
-                      onChange={handlePriceChange}
-                      placeholder={t('newListing.secondSection.price')}
+                      name="quantity"
+                      value={formData.quantity}
+                      onChange={handleQuantityChange}
+                      placeholder={t('newListing.secondSection.quantity')}
+                      className="w-36"
                       size="small"
-                      label={t('newListing.secondSection.price')}
+                      label={t('newListing.secondSection.quantity')}
                       InputProps={{
-                        startAdornment: <PaymentsIcon className="mr-2" />,
-                        endAdornment: (
-                          <span className="pl-2">
-                            {
-                              currencies.find((c) => c.code === user.currency_preference)
-                                ?.displayCurrency
-                            }
-                          </span>
-                        ),
+                        startAdornment: <TagIcon className="mr-2" />,
                       }}
                     />
+                    <Select
+                      id="condition"
+                      name="condition"
+                      size="small"
+                      placeholder="Condition"
+                      value={formData.condition}
+                      onChange={handleConditionChange}
+                      className="w-36"
+                      renderValue={(value) => (
+                        <>
+                          <DiamondIcon className="mr-2" />
+                          <span>{commonT(`conditions.${value}`)}</span>
+                        </>
+                      )}
+                    >
+                      <MenuItem disabled>
+                        <i>{t('newListing.secondSection.condition')}</i>
+                      </MenuItem>
+                      <MenuItem value="poor">{commonT('conditions.poor')}</MenuItem>
+                      <MenuItem value="played">{commonT('conditions.played')}</MenuItem>
+                      <MenuItem value="good">{commonT('conditions.good')}</MenuItem>
+                      <MenuItem value="excellent">{commonT('conditions.excellent')}</MenuItem>
+                    </Select>
                   </div>
+                  <div>
+                    <div className="w-36">
+                      <TextField
+                        type="number"
+                        name="price"
+                        value={formData.price}
+                        onChange={handlePriceChange}
+                        placeholder={t('newListing.secondSection.price')}
+                        size="small"
+                        label={t('newListing.secondSection.price')}
+                        InputProps={{
+                          startAdornment: <PaymentsIcon className="mr-2" />,
+                          endAdornment: (
+                            <span className="pl-2">
+                              {
+                                currencies.find((c) => c.code === user.currency_preference)
+                                  ?.displayCurrency
+                              }
+                            </span>
+                          ),
+                        }}
+                      />
+                    </div>
+                  </div>
+                </div>
+                <Divider className="block lg:hidden" flexItem />
+                {/* <Divider> is difficult to position vertically */}
+                <div className="hidden lg:block border-l-2 h-[120px] self-end"></div>
+                <div>
+                  <FormControlLabel
+                    control={<Checkbox />}
+                    label={t('newListing.secondSection.tradeCheckbox')}
+                  />
                 </div>
               </div>
             </div>

--- a/frontend/src/components/sellListing/ListingForm.tsx
+++ b/frontend/src/components/sellListing/ListingForm.tsx
@@ -126,6 +126,11 @@ function ListingForm(props: ListingFormProps) {
     }
   };
 
+  const handleTradeCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const checked = e.target.checked;
+    setFormData((prevFormData) => ({ ...prevFormData, is_trade_considered: checked }));
+  };
+
   const handleConditionChange = (e: SelectChangeEvent<condition>) => {
     const condition = e.target.value as condition;
     if (condition) {
@@ -292,7 +297,12 @@ function ListingForm(props: ListingFormProps) {
                 <div className="hidden lg:block border-l-2 h-[120px] self-end"></div>
                 <div>
                   <FormControlLabel
-                    control={<Checkbox />}
+                    control={
+                      <Checkbox
+                        checked={formData.is_trade_considered}
+                        onChange={handleTradeCheckboxChange}
+                      />
+                    }
                     label={t('newListing.secondSection.tradeCheckbox')}
                   />
                 </div>

--- a/frontend/src/services/yugioh/types.ts
+++ b/frontend/src/services/yugioh/types.ts
@@ -57,6 +57,7 @@ export type YugiohCardListing = {
   quantity: number;
   is_listed: boolean;
   is_sold: boolean;
+  is_trade_considered: boolean;
 };
 
 export type BuyYugiohCardListing = {
@@ -69,6 +70,7 @@ export type BuyYugiohCardListing = {
 
 export type YugiohCardSellListing = BuyYugiohCardListing & {
   quantity: number;
+  is_trade_considered: boolean;
 };
 
 export type YugiohCardInSet = {

--- a/frontend/src/services/yugioh/yugiohService.spec.ts
+++ b/frontend/src/services/yugioh/yugiohService.spec.ts
@@ -111,6 +111,7 @@ describe('yugiohService', () => {
       };
 
       const sampleListing: YugiohCardListing = {
+        is_trade_considered: false,
         id: 1,
         card: 3,
         card_name: 'test',

--- a/frontend/src/translations/bg/sell.json
+++ b/frontend/src/translations/bg/sell.json
@@ -16,6 +16,7 @@
       "visibilityButtonTooltipText_true": "Направи тази обява скрита",
       "deleteButtonText": "Изтрий",
       "deleteButtonTooltipText": "Изтрий тази обява",
+      "tradeCheckbox": "Бих обмислил оферти за размяна на тази обява",
       "marketTable": {
         "tableHeaders": {
           "seller": "Продавач",

--- a/frontend/src/translations/en/sell.json
+++ b/frontend/src/translations/en/sell.json
@@ -16,6 +16,7 @@
       "visibilityButtonTooltipText_true": "Delist",
       "deleteButtonText": "Delete",
       "deleteButtonTooltipText": "Delete this listing",
+      "tradeCheckbox": "I would consider trade offers for this listing",
       "marketTable": {
         "tableHeaders": {
           "seller": "Seller",


### PR DESCRIPTION
Closes #153 

This PR adds the checkbox from the Figma wireframes in a functional condition. On viewports < 1024px, the checkbox is below the three fields due to there being no room to put it horizontally