### PR TITLE
Implement My Trades

### DIFF
--- a/backend/trade/serializers.py
+++ b/backend/trade/serializers.py
@@ -88,7 +88,7 @@ class TradeSerializer(serializers.ModelSerializer):
         user = self.context['request'].user
 
         for listing in value:
-            if listing.user != user and listing.is_listed:
+            if listing.user == user and listing.is_listed:
                 raise serializers.ValidationError(
                     f"You can not trade with recipient's listing ids: {[listing.id for listing in value]}.")
         return value

--- a/backend/trade/serializers.py
+++ b/backend/trade/serializers.py
@@ -3,8 +3,12 @@ from rest_framework import serializers
 from .models import Trade
 from listing.models import Listing
 
+from accounts.serializers import UserSerializer
+
 
 class TradeSerializer(serializers.ModelSerializer):
+    initiator = UserSerializer(read_only=True)
+    recipient = UserSerializer(read_only=True)
     initiator_listing = serializers.PrimaryKeyRelatedField(many=True, queryset=Listing.objects.all())
     recipient_listing = serializers.PrimaryKeyRelatedField(many=True, queryset=Listing.objects.all())
 

--- a/backend/trade/views.py
+++ b/backend/trade/views.py
@@ -1,3 +1,4 @@
+from django.db import models
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
@@ -8,7 +9,6 @@ from rest_framework.permissions import IsAuthenticated
 
 from .models import Trade
 from .serializers import TradeSerializer
-from listing.models import Listing
 
 
 @extend_schema(tags=['Trade'])
@@ -20,7 +20,8 @@ class TradeListingViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        return Trade.objects.filter(initiator=user) | Trade.objects.filter(recipient=user)
+        return Trade.objects.filter(models.Q(initiator=user) | models.Q(recipient=user)
+                                    ).select_related('initiator', 'recipient')
 
     def perform_create(self, serializer):
         serializer.save(initiator=self.request.user, trade_status=Trade.NEGOTIATE)


### PR DESCRIPTION
This PR implements the backend part of Implement My Trades(issue #156 ).
The ```get_queryset``` was modified to return the ```recipiend``` and ```initiator``` user's objects:

```
{
  "count": 25,
  "next": "http://127.0.0.1:8000/api/trade/?page=2",
  "previous": null,
  "results": [
    {
      "id": 4,
      "initiator": {
        "id": 3,
        "username": "pesho",
        "email": "pesho@example.com"
      },
      "recipient": {
        "id": 2,
        "username": "simo",
        "email": "simo@example.com"
      },
      "initiator_listing": [
        10,
        11
      ],
      "recipient_listing": [
        2
      ],
      "initiator_cash": 0,
      "recipient_cash": 0,
      "trade_status": "accepted",
      "initiator_decision": "accept",
      "recipient_decision": "accept"
    },
    {
      "id": 16,
      "initiator": {
        "id": 2,
        "username": "simo",
        "email": "simo@example.com"
      },
      "recipient": {
        "id": 4,
        "username": "simo1",
        "email": "user@example.com"
      },
      "initiator_listing": [
        3,
        12
      ],
      "recipient_listing": [
        14
      ],
      "initiator_cash": 5,
      "recipient_cash": 0,
      "trade_status": "accepted",
      "initiator_decision": "accept",
      "recipient_decision": "accept"
    }
}
```