### PR TITLE
Update navigation with trade links

### DIFF
--- a/frontend/src/components/navigation/desktop/buttons/NewActionButton.tsx
+++ b/frontend/src/components/navigation/desktop/buttons/NewActionButton.tsx
@@ -38,7 +38,7 @@ function NewActionButton(): JSX.Element {
     },
     {
       label: t('navigation.newTrade'),
-      href: '#',
+      href: '/accounts/search',
     },
   ];
 

--- a/frontend/src/components/navigation/mobile/menus/MobileLoggedInNav.tsx
+++ b/frontend/src/components/navigation/mobile/menus/MobileLoggedInNav.tsx
@@ -22,6 +22,7 @@ import { toastMessages } from '../../../../constants/toast';
 import SettingsIcon from '@mui/icons-material/Settings';
 import AddShoppingCartIcon from '@mui/icons-material/AddShoppingCart';
 import CurrencyExchangeIcon from '@mui/icons-material/CurrencyExchange';
+import SyncIcon from '@mui/icons-material/Sync';
 import { OverridableComponent } from '@mui/material/OverridableComponent';
 import { useToast } from '../../../../util/useToast';
 import { useTranslation } from 'react-i18next';
@@ -71,6 +72,11 @@ function MobileLoggedInNav(props: MobileLoggedInNavProps): JSX.Element {
       href: `/user/${user.username}/sales`,
       text: t('navigation.mySales'),
       icon: CurrencyExchangeIcon,
+    },
+    {
+      href: '/trade',
+      text: t('navigation.myTrades'),
+      icon: SyncIcon,
     },
     {
       href: '/accounts/search',

--- a/frontend/src/components/navigation/mobile/menus/MobileLoggedInNav.tsx
+++ b/frontend/src/components/navigation/mobile/menus/MobileLoggedInNav.tsx
@@ -97,7 +97,7 @@ function MobileLoggedInNav(props: MobileLoggedInNavProps): JSX.Element {
       label: t('navigation.newListing'),
     },
     {
-      url: '/trade/create',
+      url: '/accounts/search',
       label: t('navigation.newTrade'),
     },
   ];

--- a/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.tsx
+++ b/frontend/src/components/navigation/profilePictureAvatar/ProfilePictureAvatar.tsx
@@ -15,6 +15,7 @@ import React, { useState } from 'react';
 import SettingsIcon from '@mui/icons-material/Settings';
 import AddShoppingCartIcon from '@mui/icons-material/AddShoppingCart';
 import CurrencyExchangeIcon from '@mui/icons-material/CurrencyExchange';
+import SyncIcon from '@mui/icons-material/Sync';
 import SearchIcon from '@mui/icons-material/Search';
 import { useLogout } from '../../../util/useLogout';
 import { toastMessages } from '../../../constants/toast';
@@ -59,6 +60,11 @@ function ProfilePictureAvatar(props: ProfilePictureAvatarProps): JSX.Element {
       href: `/user/${user.username}/sales`,
       text: t('navigation.mySales'),
       icon: CurrencyExchangeIcon,
+    },
+    {
+      href: '/trade',
+      text: t('navigation.myTrades'),
+      icon: SyncIcon,
     },
     {
       href: '/accounts/search',

--- a/frontend/src/translations/bg/common.json
+++ b/frontend/src/translations/bg/common.json
@@ -27,6 +27,7 @@
     "accountSettings": "Профилни настройки",
     "myOrders": "Моите поръчки",
     "mySales": "Моите продажби",
+    "myTrades": "Моите оферти за размяна",
     "shoppingCart": "Количка",
     "logout": "Излез от профил",
     "closeMenu": "Затвори",

--- a/frontend/src/translations/en/common.json
+++ b/frontend/src/translations/en/common.json
@@ -27,6 +27,7 @@
     "accountSettings": "Account settings",
     "myOrders": "My orders",
     "mySales": "My sales",
+    "myTrades": "My trades",
     "shoppingCart": "Shopping cart",
     "logout": "Log out",
     "closeMenu": "Close menu",


### PR DESCRIPTION
Closes #154 

Also makes the "new trade" buttons (which are next to the "new listing" ones) functional. They link to the user search page, I can change it to something else if desired