### PR TITLE
Adapt the frontend to the changes in trade statuses on the backend + fix regression with cash options

### DIFF
--- a/backend/trade/serializers.py
+++ b/backend/trade/serializers.py
@@ -63,15 +63,15 @@ class TradeSerializer(serializers.ModelSerializer):
 
         # Check for participant-specific permissions and decision updates
         if user == instance.initiator:
-            if 'recipient_decision' in validated_data or 'recipient_cash' in validated_data:
+            if 'recipient_decision' in validated_data:
                 raise serializers.ValidationError("Initiator cannot change recipient's decision or cash offer.")
-            if 'initiator_listing' in validated_data or 'initiator_cash' in validated_data:
+            if 'initiator_listing' in validated_data:
                 instance.initiator_decision = 'accept'
                 instance.recipient_decision = 'pending'
         elif user == instance.recipient:
-            if 'initiator_decision' in validated_data or 'initiator_cash' in validated_data:
+            if 'initiator_decision' in validated_data:
                 raise serializers.ValidationError("Recipient cannot change initiator's decision or cash offer.")
-            if 'recipient_listing' in validated_data or 'recipient_cash' in validated_data:
+            if 'recipient_listing' in validated_data:
                 instance.recipient_decision = 'accept'
                 instance.initiator_decision = 'pending'
 

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -62,7 +62,6 @@ export const api = Object.freeze({
     negotiate: (id: number | string) => `${trade}/${id}/negotiate/`,
     accept: (id: number | string) => `${trade}/${id}/accept/`,
     reject: (id: number | string) => `${trade}/${id}/reject/`,
-    counterOffer: (id: number | string) => `${trade}/${id}/counter-offer/`,
     chat: {
       byTradeId: (id: number | string) => `${tradeChat}/${id}/`,
     },

--- a/frontend/src/services/trade/trade.ts
+++ b/frontend/src/services/trade/trade.ts
@@ -37,7 +37,7 @@ export const tradeService = {
   },
 
   async negotiate(tradeId: number, trade: Partial<TradeRequest>): Promise<Trade> {
-    const data = await httpService.post<Trade>(api.trade.negotiate(tradeId), trade);
+    const data = await httpService.patch<Trade>(api.trade.negotiate(tradeId), trade);
     return data!;
   },
 
@@ -47,12 +47,12 @@ export const tradeService = {
   },
 
   async accept(tradeId: number): Promise<TradeStatusUpdateResponse> {
-    const data = await httpService.post<TradeStatusUpdateResponse>(api.trade.accept(tradeId));
+    const data = await httpService.patch<TradeStatusUpdateResponse>(api.trade.accept(tradeId));
     return data!;
   },
 
   async reject(tradeId: number): Promise<TradeStatusUpdateResponse> {
-    const data = await httpService.post<TradeStatusUpdateResponse>(api.trade.reject(tradeId));
+    const data = await httpService.patch<TradeStatusUpdateResponse>(api.trade.reject(tradeId));
     return data!;
   },
 

--- a/frontend/src/services/trade/trade.ts
+++ b/frontend/src/services/trade/trade.ts
@@ -41,11 +41,6 @@ export const tradeService = {
     return data!;
   },
 
-  async counterOffer(tradeId: number, trade: Partial<TradeRequest>): Promise<Trade> {
-    const data = await httpService.post<Trade>(api.trade.counterOffer(tradeId), trade);
-    return data!;
-  },
-
   async accept(tradeId: number): Promise<TradeStatusUpdateResponse> {
     const data = await httpService.patch<TradeStatusUpdateResponse>(api.trade.accept(tradeId));
     return data!;


### PR DESCRIPTION
#175 

This PR does two things:

**Trade API adaptation**

This PR updates the frontend with the changes to the trades API on the backend. In this case, the only real changes here are that the negotiate/accept/reject actions are now PATCH requests and that the counter offer API has been removed entirely (as it was unused). As far as I have seen, the frontend itself handles the different scenarios regarding trade statuses accurately without any additional changes, so if there's something specific that is still not correct (except for #176, which should be handled in a different PR) that I have missed, it should probably be mentioned.

**Cash options regression fix**
#179 introduced a regression that prevented an initiator from specifying a cash option for the recipient and vice-versa, which is not the correct behavior. This PR fixes the regression by simply removing the validation on the backend that was causing it.