### PR TITLE
Integrate missing features regarding system messages on the frontend

### DIFF
--- a/frontend/src/pages/trade/TradeDetails.tsx
+++ b/frontend/src/pages/trade/TradeDetails.tsx
@@ -43,6 +43,7 @@ function TradeDetails(): JSX.Element {
         }
 
         setModalIsOpen(false);
+        updateChatMessages();
         return tradeService.findTradeById(id);
       })
       .then(transformOffer)
@@ -64,6 +65,7 @@ function TradeDetails(): JSX.Element {
         }
 
         setModalIsOpen(false);
+        updateChatMessages();
         return tradeService.findTradeById(id);
       })
       .then(transformOffer)
@@ -87,6 +89,7 @@ function TradeDetails(): JSX.Element {
       .then((data) => {
         populate(data);
         setModalIsOpen(false);
+        updateChatMessages();
         toast.success({ toastKey: toastMessages.tradeHasBeenNegotiated, values: { id } });
       })
       .catch(toast.error);


### PR DESCRIPTION
#177 

This PR isn't particularly big, because system messages were mostly functional on the frontend when they were implemented on the backend. The only missing thing was that accept/negotiate/reject events did not refresh the chat and I felt it would make for a jarring experience if those events didn't update the chat at least.

With that said, though, there are a bunch of issues that I have left out, as they are out of scope for this PR and/or will require some further tweaking on the backend.

![Screenshot_13](https://github.com/user-attachments/assets/8b27e340-11eb-45cc-871b-5c0eb9716206)
1. When a user initiates a trade, a rather empty message is generated (see the first one in the image above). This is because the frontend automatically sends a request to create the trade when the user initiates a trade via the UI. And the reason why I did this early on is because the backend technically does not disallow empty trades. I could potentially tackle this both on the frontend and the backend if we want to make it so that a trade request cannot be empty (i.e. requires at least one listing or cash option from both sides), but it would probably be more ideal to open a separate issue for this.
2. There is no bolding whatsoever, as injecting any formatting with the current setup would require some pretty serious regex matching to achieve this. It's not *technically* impossible, but it's questionable whether the result would justify the monstrous regexes that will inevitably pop up. Another potential concern with injecting formatting is that I'd be exposing the app to potential XSS attacks (granted, those messages are all generated by the server, but it would be ideal to avoid injecting HTML when possible)
3. All system messages are pink / purple (I am bad with colors, don't judge me) because the frontend uses the author to determine which color to use. However, none of the system messages designate an author, so it erroneously defaults to the color of the other user. The backend should either designate the "initiator" of the event or the system messages should use a third, more neutral color
4. The messages aren't translated to Bulgarian, as the frontend simply uses the message's content. Due to its dynamic nature, it is obviously unfeasible to give it some translation key (without relying on yet another regex monstrosity to extract the listings and cash option)

Let me know if I missed anything