### PR TITLE
Fix issue with first search item's clickability

### DIFF
--- a/frontend/src/components/searchField/SearchResultsDisplay.tsx
+++ b/frontend/src/components/searchField/SearchResultsDisplay.tsx
@@ -38,7 +38,7 @@ function SearchResultsDisplay(props: SearchResultsDisplayProps): JSX.Element {
 
   return (
     <List
-      className="border rounded-lg w-full"
+      className="border rounded-lg w-full z-50"
       sx={{
         position: 'absolute',
         backgroundColor: 'white',


### PR DESCRIPTION
Closes #184 

The issue was caused by the fact the results display element did not have a higher ``z-index`` than the breadcrumb navigation (thus the navigation was "covering" that search item). This is an important detail, as the issue was not reproducible on all pages (the only instances of the issue I had stumbled upon were all in pages with that breadcrumb navigation menu).

As far as I have tested, this issue does not affect the mobile variant of the search, so nothing has been touched there.

If there are other pages where this issue occurs, please let me know (I have tested a few pages and have not reproduced the issue since the bugfix commit)